### PR TITLE
Disable FileWatcherHandler for macOS

### DIFF
--- a/fastddsspy_tool/src/cpp/main.cpp
+++ b/fastddsspy_tool/src/cpp/main.cpp
@@ -174,9 +174,11 @@ int main(
                     }
                 };
 
+#if !defined(__APPLE__)
         // Creating FileWatcher event handler
         std::unique_ptr<eprosima::utils::event::FileWatcherHandler> file_watcher_handler =
                 std::make_unique<eprosima::utils::event::FileWatcherHandler>(filewatcher_callback, file_path);
+#endif // !defined(__APPLE__)
 
         /////
         // Periodic Handler for reload configuration in periodic time
@@ -233,10 +235,12 @@ int main(
             periodic_handler.reset();
         }
 
+#if !defined(__APPLE__)
         if (file_watcher_handler)
         {
             file_watcher_handler.reset();
         }
+#endif // !defined(__APPLE__)
     }
     catch (const eprosima::utils::ConfigurationException& e)
     {


### PR DESCRIPTION
The `FileWatcherHandler`class is not supported on macOS. This PR conditionally excludes it to enable Fast DDS Spy to be build on macOS.

### Dependencies

- https://github.com/eProsima/dev-utils/pull/81
- https://github.com/eProsima/Fast-DDS-statistics-backend/pull/195

### Testing

System: Mac Pro 2019, 3.2 GHz 16-Core Intel Xeon W
OS: macOS Ventura Version 13.5
Xcode: 14.3.1
ROS: ROS 2 Humble (built from source for macOS)

Figure: fastddspy displaying topics for ArduPilot DDS
![fastddsspy](https://github.com/eProsima/Fast-DDS-spy/assets/24916364/6a7c9211-4ad6-4b28-b8d7-32a425913b18)

