### PR TITLE
Manually fix a set of Topic QoS, and implement the max-rx-rate and downsampling

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -108,15 +108,14 @@ Other option may be to not using Shared Memory by disabling it by Fast DDS confi
 
 This first version does support the following configurations:
 
-|                      | Description                                                 | Type           | Default   |
-|----------------------|-------------------------------------------------------------|----------------|-----------|
-| dds/allowlist        | List of topics that the tool will subscribe to              | List of topics | Empty     |
-| dds/blocklist        | List of topics that the tool will **not** subscribe to      | List of topics | Empty     |
-| dds/domain           | DDS Domain to discover and subscribe to topics allowed      | integer        | 0         |
-| dds/ros2-types       | Display information in either ROS 2 format (true) or the raw DDS format (false)| bool           | false     |
-| specs/threads        | Number of threads to read DDS data                          | int            | 12        |
-| specs/discovery-time | Time before showing info when using one-shot command        | int (ms)       | 1000      |
-| specs/max-depth      | Maximum history depth for DataReaders                       | int            | 5000      |
+|                         | Description                                                 | Type           | Default   |
+|-------------------------|-------------------------------------------------------------|----------------|-----------|
+| dds/allowlist           | List of topics that the tool will subscribe to              | List of topics | Empty     |
+| dds/blocklist           | List of topics that the tool will **not** subscribe to      | List of topics | Empty     |
+| dds/domain              | DDS Domain to discover and subscribe to topics allowed      | integer        | 0         |
+| specs/threads           | Number of threads to read DDS data                          | int            | 12        |
+| specs/discovery-time    | Time before showing info when using one-shot command        | int (ms)       | 1000      |
+| specs/qos/history-depth | Maximum history depth for DataReaders                       | int            | 5000      |
 
 The topics in `allowlist` and `blocklist` are filled with elements with field `name` referring to the Topic name.
 Optionally each element can have the element `type` referring to the Topic Data Type name.

--- a/docker/resources/complete_configuration.yaml
+++ b/docker/resources/complete_configuration.yaml
@@ -30,5 +30,6 @@ specs:
   # Time elapsed in milliseconds when using tool as one-shot to wait and gather data from the network (Default: 1000)
   discovery-time: 1000
 
-  # Max history depth by default for every DataReader of every topic (Default: 5000)
-  max-depth: 5000
+  qos:
+    # History depth by default for every DataReader in every topic (Default: 5000)
+    history-depth: 5000

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -13,3 +13,4 @@ This release will include the following **Configuration features**:
 * :ref:`Manual Topics <user_manual_configuration_dds__manual_topics>`.
 * :ref:`Max Reception Rate <user_manual_configuration_dds__max_rx_rate>`.
 * :ref:`Downsampling <user_manual_configuration_dds__downsampling>`.
+* Remove the support for Built-in Topics.

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -10,3 +10,4 @@ Forthcoming Version
 This release will include the following **Configuration features**:
 
 * Display information in either ROS 2 format or the raw DDS format.
+* :ref:`Manual Topics <user_manual_configuration_manual_topics>`.

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -11,5 +11,5 @@ This release will include the following **Configuration features**:
 
 * Display information in either ROS 2 format or the raw DDS format.
 * :ref:`Manual Topics <user_manual_configuration_dds__manual_topics>`.
-* :ref:`Max Reception Rate <user_manual_configuration_max_rx_rate>`.
-* :ref:`Downsampling <user_manual_configuration_downsampling>`.
+* :ref:`Max Reception Rate <user_manual_configuration_dds__max_rx_rate>`.
+* :ref:`Downsampling <user_manual_configuration_dds__downsampling>`.

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -11,3 +11,5 @@ This release will include the following **Configuration features**:
 
 * Display information in either ROS 2 format or the raw DDS format.
 * :ref:`Manual Topics <user_manual_configuration_manual_topics>`.
+* :ref:`Max Reception Rate <user_manual_configuration_max_rx_rate>`.
+* :ref:`Downsampling <user_manual_configuration_downsampling>`.

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -10,6 +10,6 @@ Forthcoming Version
 This release will include the following **Configuration features**:
 
 * Display information in either ROS 2 format or the raw DDS format.
-* :ref:`Manual Topics <user_manual_configuration_manual_topics>`.
+* :ref:`Manual Topics <user_manual_configuration_dds__manual_topics>`.
 * :ref:`Max Reception Rate <user_manual_configuration_max_rx_rate>`.
 * :ref:`Downsampling <user_manual_configuration_downsampling>`.

--- a/docs/rst/notes/notes.rst
+++ b/docs/rst/notes/notes.rst
@@ -2,7 +2,10 @@
 
 .. _notes:
 
+<<<<<<< HEAD
 .. TODO uncomment when there are forthcoming notes
+=======
+>>>>>>> 3eeea2f (Apply suggestions)
 .. include:: forthcoming_version.rst
 
 ##############

--- a/docs/rst/notes/notes.rst
+++ b/docs/rst/notes/notes.rst
@@ -2,10 +2,6 @@
 
 .. _notes:
 
-<<<<<<< HEAD
-.. TODO uncomment when there are forthcoming notes
-=======
->>>>>>> 3eeea2f (Apply suggestions)
 .. include:: forthcoming_version.rst
 
 ##############

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -147,7 +147,8 @@ For more information on topics, please read the `Fast DDS Topic <https://fast-dd
 
 .. warning::
 
-    The ``TRANSIENT_LOCAL`` durability is not compatible with the ``BEST_EFFORT`` reliability.
+    Manually configuring ``TRANSIENT_LOCAL`` durability may lead to incompatibility issues when the discovered reliability is ``BEST_EFFORT``.
+    Please ensure to always configure the ``reliability`` when configuring the ``durability`` to avoid the issue.
 
 .. _user_manual_configuration_dds__history_depth:
 

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -106,6 +106,53 @@ See `Interface Whitelist <https://fast-dds.docs.eprosima.com/en/latest/fastdds/t
 
     When providing an interface whitelist, external participants with which communication is desired must also be configured with interface whitelisting.
 
+.. _user_manual_configuration_dds__manual_topics:
+
+Topics
+------
+
+A subset of QoSs can be manually configured for a specific topic under the tag ``topics``.
+The tag ``topics`` has a required ``name`` tag that accepts wildcard characters.
+It also has two optional tags: a ``type`` tag that accepts wildcard characters, and a ``qos`` tag with the QoSs that the user wants to manually configure.
+If a ``qos`` is not manually configured, it will get its value by discovery.
+
+**Example of usage**
+
+.. code-block:: yaml
+
+    topics:
+      - name: temperature/*
+        type: temperature/types/*
+        qos:
+            reliability: true
+
+.. _user_manual_configuration_dds__builtin_topics:
+
+Built-in Topics
+---------------
+
+Apart from the dynamic DDS topics discovered in the network, the discovery phase can be accelerated by using the builtin topic list (``builtin-topics``).
+By defining topics in this list, the |ddsrecorder| will create the DataWriters and DataReaders in recorder initialization.
+
+The builtin-topics list is defined in the same form as the ``allowlist`` and ``blocklist``.
+
+This feature also allows to manually force the QoS of a specific topic, so the entities created in such topic follows the specified QoS and not the one first discovered.
+
+**Example of usage:**
+
+    .. code-block:: yaml
+
+        builtin-topics:
+          - name: HelloWorldTopic
+            type: HelloWorld
+            qos:
+              reliability: true       # Use QoS RELIABLE
+              durability: true        # Use QoS TRANSIENT_LOCAL
+              depth: 100              # Use History Depth 100
+              partitions: true        # Topic with partitions
+              ownership: false        # Use QoS SHARED_OWNERSHIP_QOS
+              keyed: true             # Topic with key
+
 Topic Filtering
 ---------------
 
@@ -227,6 +274,12 @@ This is a YAML file that uses all supported configurations and set them as defau
       blocklist:
         - name: "topic_name"
           type: "topic_type"
+
+      topics:
+        - name: temperature/*
+          type: temperature/types/*
+          qos:
+            reliability: true
 
       builtin-topics:
         - name: "HelloWorldTopic"

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -10,24 +10,6 @@ Configuration
 A |spy| instance can be configured by a :term:`YAML` configuration file.
 In order to retrieve a configuration file to a |spy|, use :ref:`user_manual_user_interface_configuration_file_argument`.
 
-Version
-=======
-
-The YAML Configuration support a ``version`` value to identify the configuration version to parse the file.
-In future releases could be common to change the YAML format (some key words, fields, etc.).
-This value allow to keep using the same YAML file using an old configuration format, maintaining compatibility.
-
-.. list-table::
-    :header-rows: 1
-
-    *   - Configuration Versions
-        - String in ``version`` tag
-        - |spy| activation release
-
-    *   - version 2.0
-        - ``v2.0``
-        - *v0.2.0*
-
 .. _user_manual_configuration_dds:
 
 DDS Configurations
@@ -322,8 +304,6 @@ This is a YAML file that uses all supported configurations and set them as defau
     This example can be used as a quick reference, but it may not be correct due to incompatibility or exclusive properties. **Do not take it as a working example**.
 
 .. code-block:: yaml
-
-    version: 2.0
 
     dds:
       domain: 0

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -24,9 +24,9 @@ This value allow to keep using the same YAML file using an old configuration for
         - String in ``version`` tag
         - |spy| activation release
 
-    *   - version 1.0
-        - ``v1.0``
-        - *v0.1.0*
+    *   - version 2.0
+        - ``v2.0``
+        - *v0.2.0*
 
 .. _user_manual_configuration_dds:
 
@@ -42,15 +42,15 @@ Topic Filtering
 ---------------
 
 The |spy| automatically detects the topics that are being used in a DDS Network.
-The |spy| then creates internal DDS :term:`Readers<DataReader>` for each topic to forward the data published.
+The |spy| then creates internal DDS :term:`Readers<DataReader>` for each topic to process the data published.
 
 .. note::
 
     |spy| entities are created with the :ref:`Topic QoS <user_manual_configuration_dds__topic_qos>` of the first Subscriber found in this Topic.
 
-The |spy| allows filtering DDS :term:`Topics<Topic>`, that is, it allows users to configure the DDS :term:`Topics<Topic>` that must be forwarded.
+The |spy| allows filtering DDS :term:`Topics<Topic>`, that is, it allows users to configure the DDS :term:`Topics<Topic>` to process.
 These data filtering rules can be configured under the ``allowlist`` and ``blocklist`` tags.
-If the ``allowlist`` and ``blocklist`` are not configured, the |spy| will forward all the data published on the topics it discovers.
+If the ``allowlist`` and ``blocklist`` are not configured, the |spy| will process all the data published on the topics it discovers.
 If both the ``allowlist`` and ``blocklist`` are configured and a topic appears in both of them, the ``blocklist`` has priority and the topic will be blocked.
 
 Topics are determined by the tags ``name`` (required) and ``type``, both of which accept wildcard characters.
@@ -77,7 +77,7 @@ Consider the following example:
       - name: "*"
         type: HelloWorld
 
-In this example, the data in the topic ``AllowedTopic1`` with type ``Allowed`` and the data in the topic ``AllowedTopic2`` with any type will be forwarded by the |spy|.
+In this example, the data in the topic ``AllowedTopic1`` with type ``Allowed`` and the data in the topic ``AllowedTopic2`` with any type will be processed by the |spy|.
 The data in the topic ``HelloWorldTopic`` with type ``HelloWorld`` will be blocked, since the ``blocklist`` is blocking all topics with any name and with type ``HelloWorld``.
 
 .. _user_manual_configuration_dds__topic_qos:
@@ -145,15 +145,18 @@ For more information on topics, please read the `Fast DDS Topic <https://fast-dd
         - ``1``
         - :ref:`user_manual_configuration_dds__downsampling`
 
+.. warning::
+
+    The ``TRANSIENT_LOCAL`` durability is not compatible with the ``BEST_EFFORT`` reliability.
+
 .. _user_manual_configuration_dds__history_depth:
 
 History Depth
 ^^^^^^^^^^^^^
 
 The ``history-depth`` tag configures the history depth of the Fast DDS internal entities.
-By default, the depth of every RTPS History instance is :code:`5000`, which sets a constraint on the maximum number of samples a |spy| instance can deliver to late joiner Readers configured with ``TRANSIENT_LOCAL`` `DurabilityQosPolicyKind <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/core/policy/standardQosPolicies.html#durabilityqospolicykind>`_.
+By default, the depth of every RTPS History instance is :code:`5000`.
 Its value should be decreased when the sample size and/or number of created endpoints (increasing with the number of topics) are big enough to cause memory exhaustion issues.
-If enough memory is available, however, the ``history-depth`` could be increased to deliver a greater number of samples to late joiners.
 
 .. _user_manual_configuration_dds__max_rx_rate:
 
@@ -324,7 +327,7 @@ This is a YAML file that uses all supported configurations and set them as defau
 
 .. code-block:: yaml
 
-    version: 1.0
+    version: 2.0
 
     dds:
       domain: 0

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -36,24 +36,6 @@ DDS Configurations
 The YAML Configuration supports a ``dds`` **optional** tag that contains certain :term:`DDS` configurations.
 The values available to configure are:
 
-.. _user_manual_configuration_dds__builtin_topics:
-
-Built-in Topics
----------------
-
-The discovery phase can be accelerated by listing topics under the ``builtin-topics`` tag.
-The |spy| will create the DataWriters and DataReaders for these topics in the |spy| initialization.
-The :ref:`Topic QoS <user_manual_configuration_dds__topic_qos>` for these topics can be manually configured with a :ref:`Manual Topic <user_manual_configuration_dds__manual_topics>` and with the :ref:`Specs Topic QoS <user_manual_configuration_specs_topic_qos>`; if a :ref:`Topic QoS <user_manual_configuration_dds__topic_qos>` is not configured, it will take its default value.
-
-The ``builtin-topics`` must specify a ``name`` and ``type`` without wildcard characters.
-
-
-.. code-block:: yaml
-
-    builtin-topics:
-      - name: HelloWorldTopic
-        type: HelloWorld
-
 .. _user_manual_configuration_dds__topic_filtering:
 
 Topic Filtering
@@ -354,10 +336,6 @@ This is a YAML file that uses all supported configurations and set them as defau
       blocklist:
         - name: "topic_name"
           type: "topic_type"
-
-      builtin-topics:
-        - name: "HelloWorldTopic"
-          type: "HelloWorld"
 
       topics:
         - name: "temperature/*"

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -157,7 +157,7 @@ For more information on topics, please read the `Fast DDS Topic <https://fast-dd
         - ``0`` (unlimited)
         - :ref:`user_manual_configuration_dds__max_rx_rate`
 
-    *   - Down-sampling
+    *   - Downsampling
         - ``downsampling``
         - *unsigned integer*
         - ``1``
@@ -188,7 +188,7 @@ Downsampling
 ^^^^^^^^^^^^
 
 The ``downsampling`` tag reduces the sampling rate of the received data by only keeping *1* out of every *n* samples received (per topic), where *n* is the value specified under the ``downsampling`` tag.
-When the ``max-rx-rate`` tag is also set, down-sampling only applies to messages that have passed the ``max-rx-rate`` filter.
+When the ``max-rx-rate`` tag is also set, downsampling only applies to messages that have passed the ``max-rx-rate`` filter.
 It only accepts positive integers.
 By default it is set to ``1``; it accepts every message.
 
@@ -327,7 +327,7 @@ QoS
 
 .. note::
 
-    The :ref:`Topic QoS <user_manual_configuration_dds__topic_qos>` configured in ``specs`` can be overwritten by the :ref:`Manual Topics <user_manual_configuration_specs_topic_qos>`.
+    The :ref:`Topic QoS <user_manual_configuration_dds__topic_qos>` configured in ``specs`` can be overwritten by the :ref:`Manual Topics <user_manual_configuration_dds__manual_topics>`.
 
 .. _user_manual_configuration_default:
 

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -108,8 +108,8 @@ See `Interface Whitelist <https://fast-dds.docs.eprosima.com/en/latest/fastdds/t
 
 .. _user_manual_configuration_dds__manual_topics:
 
-Topics
-------
+Manual Topics
+-------------
 
 A subset of QoSs can be manually configured for a specific topic under the tag ``topics``.
 The tag ``topics`` has a required ``name`` tag that accepts wildcard characters.
@@ -132,7 +132,7 @@ Built-in Topics
 ---------------
 
 Apart from the dynamic DDS topics discovered in the network, the discovery phase can be accelerated by using the builtin topic list (``builtin-topics``).
-By defining topics in this list, the |ddsrecorder| will create the DataWriters and DataReaders in recorder initialization.
+By defining topics in this list, the |spy| will create the DataWriters and DataReaders in recorder initialization.
 
 The builtin-topics list is defined in the same form as the ``allowlist`` and ``blocklist``.
 
@@ -311,7 +311,7 @@ This is a YAML file that uses all supported configurations and set them as defau
             partitions: true
             ownership: false
             downsampling: 4
-            max-reception-rate: 10
+            max-rx-rate: 10
 
       ignore-participant-flags: no_filter
       transport: builtin

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -43,11 +43,6 @@ Topic Filtering
 
 The |spy| automatically detects the topics that are being used in a DDS Network.
 The |spy| then creates internal DDS :term:`Readers<DataReader>` for each topic to process the data published.
-
-.. note::
-
-    |spy| entities are created with the :ref:`Topic QoS <user_manual_configuration_dds__topic_qos>` of the first Subscriber found in this Topic.
-
 The |spy| allows filtering DDS :term:`Topics<Topic>`, that is, it allows users to configure the DDS :term:`Topics<Topic>` to process.
 These data filtering rules can be configured under the ``allowlist`` and ``blocklist`` tags.
 If the ``allowlist`` and ``blocklist`` are not configured, the |spy| will process all the data published on the topics it discovers.

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -36,77 +36,6 @@ DDS Configurations
 The YAML Configuration supports a ``dds`` **optional** tag that contains certain :term:`DDS` configurations.
 The values available to configure are:
 
-DDS Domain Id
--------------
-
-In order to execute a |spy| instance in a :term:`Domain Id` different than the default (``0``) use tag ``domain``.
-
-.. _user_manual_configuration_dds_ignore_participant_flags:
-
-Ignore Participant Flags
-------------------------
-
-A set of discovery traffic filters can be defined in order to add an extra level of isolation.
-This configuration option can be set through the ``ignore-participant-flags`` tag:
-
-.. code-block:: yaml
-
-    ignore-participant-flags: no_filter                          # No filter (default)
-    # or
-    ignore-participant-flags: filter_different_host              # Discovery traffic from another host is discarded
-    # or
-    ignore-participant-flags: filter_different_process           # Discovery traffic from another process on same host is discarded
-    # or
-    ignore-participant-flags: filter_same_process                # Discovery traffic from own process is discarded
-    # or
-    ignore-participant-flags: filter_different_and_same_process  # Discovery traffic from own host is discarded
-
-See `Ignore Participant Flags <https://fast-dds.docs.eprosima.com/en/latest/fastdds/discovery/general_disc_settings.html?highlight=ignore%20flags#ignore-participant-flags>`_ for more information.
-
-
-.. _user_manual_configuration_dds_custom_transport_descriptors:
-
-Custom Transport Descriptors
-----------------------------
-
-By default, |spy| internal participants are created with enabled `UDP <https://fast-dds.docs.eprosima.com/en/latest/fastdds/transport/udp/udp.html>`_ and `Shared Memory <https://fast-dds.docs.eprosima.com/en/latest/fastdds/transport/shared_memory/shared_memory.html>`_ transport descriptors.
-The use of one or the other for communication will depend on the specific scenario, and whenever both are viable candidates, the most efficient one (Shared Memory Transport) is automatically selected.
-However, a user may desire to force the use of one of the two, which can be accomplished via the ``transport`` configuration tag.
-
-.. code-block:: yaml
-
-    transport: builtin    # UDP & SHM (default)
-    # or
-    transport: udp        # UDP only
-    # or
-    transport: shm        # SHM only
-
-.. warning::
-
-    When configured with ``transport: shm``, |spy| will only communicate with applications using Shared Memory Transport exclusively (with disabled UDP transport).
-
-
-.. _user_manual_configuration_dds__interface_whitelist:
-
-Interface Whitelist
--------------------
-
-Optional tag ``whitelist-interfaces`` allows to limit the network interfaces used by UDP and TCP transport.
-This may be useful to only allow communication within the host (note: same can be done with :ref:`user_manual_configuration_dds_ignore_participant_flags`).
-Example:
-
-.. code-block:: yaml
-
-    whitelist-interfaces:
-      - "127.0.0.1"    # Localhost only
-
-See `Interface Whitelist <https://fast-dds.docs.eprosima.com/en/latest/fastdds/transport/whitelist.html>`_ for more information.
-
-.. warning::
-
-    When providing an interface whitelist, external participants with which communication is desired must also be configured with interface whitelisting.
-
-
 .. _user_manual_configuration_dds__builtin_topics:
 
 Built-in Topics
@@ -114,7 +43,7 @@ Built-in Topics
 
 The discovery phase can be accelerated by listing topics under the ``builtin-topics`` tag.
 The |spy| will create the DataWriters and DataReaders for these topics in the |spy| initialization.
-The :ref:`Topic QoS <user_manual_configuration_dds__topic_qos>` for these topics can be manually configured with a :ref:`Manual Topic <user_manual_configuration_dds__manual_topics>`; if a :ref:`Topic QoS <user_manual_configuration_dds__topic_qos>` is not configured, it will take its default value.
+The :ref:`Topic QoS <user_manual_configuration_dds__topic_qos>` for these topics can be manually configured with a :ref:`Manual Topic <user_manual_configuration_dds__manual_topics>` and with the :ref:`Specs Topic QoS <user_manual_configuration_specs_topic_qos>`; if a :ref:`Topic QoS <user_manual_configuration_dds__topic_qos>` is not configured, it will take its default value.
 
 The ``builtin-topics`` must specify a ``name`` and ``type`` without wildcard characters.
 
@@ -137,7 +66,7 @@ The |spy| then creates internal DDS :term:`Readers<DataReader>` for each topic t
 
     |spy| entities are created with the :ref:`Topic QoS <user_manual_configuration_dds__topic_qos>` of the first Subscriber found in this Topic.
 
-The |spy| allows filtering DDS :term:`Topics<Topic>`, that is, it allows users to configure which DDS :term:`Topics<Topic>` should be forwarded by the application.
+The |spy| allows filtering DDS :term:`Topics<Topic>`, that is, it allows users to configure the DDS :term:`Topics<Topic>` that must be forwarded.
 These data filtering rules can be configured under the ``allowlist`` and ``blocklist`` tags.
 If the ``allowlist`` and ``blocklist`` are not configured, the |spy| will forward all the data published on the topics it discovers.
 If both the ``allowlist`` and ``blocklist`` are configured and a topic appears in both of them, the ``blocklist`` has priority and the topic will be blocked.
@@ -218,7 +147,7 @@ For more information on topics, please read the `Fast DDS Topic <https://fast-dd
 
     *   - History Depth
         - ``history-depth``
-        - *integer*
+        - *unsigned integer*
         - ``5000``
         - :ref:`user_manual_configuration_dds__history_depth`
 
@@ -276,14 +205,84 @@ If a ``qos`` is not manually configured, it will get its value by discovery.
 .. code-block:: yaml
 
     topics:
-      - name: temperature/*
-        type: temperature/types/*
+      - name: "temperature/*"
+        type: "temperature/types/*"
         qos:
           max-tx-rate: 15
           downsampling: 2
-        participants:
-          - Participant0
-          - Participant1
+
+.. note::
+
+    The :ref:`Topic QoS <user_manual_configuration_dds__topic_qos>` configured in the Manual Topics take precedence over the :ref:`Specs Topic QoS <user_manual_configuration_specs_topic_qos>`.
+
+DDS Domain Id
+-------------
+
+In order to execute a |spy| instance in a :term:`Domain Id` different than the default (``0``) use tag ``domain``.
+
+.. _user_manual_configuration_dds_ignore_participant_flags:
+
+Ignore Participant Flags
+------------------------
+
+A set of discovery traffic filters can be defined in order to add an extra level of isolation.
+This configuration option can be set through the ``ignore-participant-flags`` tag:
+
+.. code-block:: yaml
+
+    ignore-participant-flags: no_filter                          # No filter (default)
+    # or
+    ignore-participant-flags: filter_different_host              # Discovery traffic from another host is discarded
+    # or
+    ignore-participant-flags: filter_different_process           # Discovery traffic from another process on same host is discarded
+    # or
+    ignore-participant-flags: filter_same_process                # Discovery traffic from own process is discarded
+    # or
+    ignore-participant-flags: filter_different_and_same_process  # Discovery traffic from own host is discarded
+
+See `Ignore Participant Flags <https://fast-dds.docs.eprosima.com/en/latest/fastdds/discovery/general_disc_settings.html?highlight=ignore%20flags#ignore-participant-flags>`_ for more information.
+
+.. _user_manual_configuration_dds_custom_transport_descriptors:
+
+Custom Transport Descriptors
+----------------------------
+
+By default, |spy| internal participants are created with enabled `UDP <https://fast-dds.docs.eprosima.com/en/latest/fastdds/transport/udp/udp.html>`_ and `Shared Memory <https://fast-dds.docs.eprosima.com/en/latest/fastdds/transport/shared_memory/shared_memory.html>`_ transport descriptors.
+The use of one or the other for communication will depend on the specific scenario, and whenever both are viable candidates, the most efficient one (Shared Memory Transport) is automatically selected.
+However, a user may desire to force the use of one of the two, which can be accomplished via the ``transport`` configuration tag.
+
+.. code-block:: yaml
+
+    transport: builtin    # UDP & SHM (default)
+    # or
+    transport: udp        # UDP only
+    # or
+    transport: shm        # SHM only
+
+.. warning::
+
+    When configured with ``transport: shm``, |spy| will only communicate with applications using Shared Memory Transport exclusively (with disabled UDP transport).
+
+
+.. _user_manual_configuration_dds__interface_whitelist:
+
+Interface Whitelist
+-------------------
+
+Optional tag ``whitelist-interfaces`` allows to limit the network interfaces used by UDP and TCP transport.
+This may be useful to only allow communication within the host (note: same can be done with :ref:`user_manual_configuration_dds_ignore_participant_flags`).
+Example:
+
+.. code-block:: yaml
+
+    whitelist-interfaces:
+      - "127.0.0.1"    # Localhost only
+
+See `Interface Whitelist <https://fast-dds.docs.eprosima.com/en/latest/fastdds/transport/whitelist.html>`_ for more information.
+
+.. warning::
+
+    When providing an interface whitelist, external participants with which communication is desired must also be configured with interface whitelisting.
 
 Topic type format
 -----------------
@@ -319,10 +318,16 @@ Discovery Time
 This parameter is useful for very big networks, as |spy| may not discover the whole network fast enough to return a complete information.
 By default, this value is ``1000`` (1 second).
 
+.. _user_manual_configuration_specs_topic_qos:
+
 QoS
 ---
 
 ``specs`` supports a ``qos`` **optional** tag to configure the default values of the :ref:`Topic QoS <user_manual_configuration_dds__topic_qos>`.
+
+.. note::
+
+    The :ref:`Topic QoS <user_manual_configuration_dds__topic_qos>` configured in ``specs`` can be overwritten by the :ref:`Manual Topics <user_manual_configuration_specs_topic_qos>`.
 
 .. _user_manual_configuration_default:
 
@@ -343,16 +348,16 @@ This is a YAML file that uses all supported configurations and set them as defau
       domain: 0
 
       allowlist:
-        - name: topic_name
-          type: topic_type
+        - name: "topic_name"
+          type: "topic_type"
 
       blocklist:
-        - name: topic_name
-          type: topic_type
+        - name: "topic_name"
+          type: "topic_type"
 
       builtin-topics:
-        - name: HelloWorldTopic
-          type: HelloWorld
+        - name: "HelloWorldTopic"
+          type: "HelloWorld"
 
       topics:
         - name: "temperature/*"

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -249,6 +249,25 @@ Discovery Time
 This parameter is useful for very big networks, as |spy| may not discover the whole network fast enough to return a complete information.
 By default, this value is ``1000`` (1 second).
 
+.. _user_manual_configuration_max_rx_rate:
+
+Max Reception Rate
+------------------
+
+Limits the frequency [Hz] at which samples are processed, by discarding messages received before :code:`1/max-rx-rate` seconds have elapsed since the last processed message was received.
+When specified, ``max-rx-rate`` is set for all topics without distinction, but a different value can also set for a particular topic under the ``qos`` configuration tag within the builtin-topics list.
+This parameter only accepts non-negative values, and its default value is ``0`` (no limit).
+
+.. _user_manual_configuration_downsampling:
+
+Downsampling
+------------
+
+Reduces the sampling rate of the received data by keeping *1* out of every *n* samples received (per topic), where *n* is the value specified in ``downsampling``.
+If ``max-rx-rate`` is also set, downsampling applies to messages that already managed to pass this filter.
+When specified, this downsampling factor is set for all topics without distinction, but a different value can also set for a particular topic under the ``qos`` configuration tag within the builtin-topics list.
+This parameter only accepts positive integer values, and its default value is ``1`` (no downsampling).
+
 .. _user_manual_configuration_default:
 
 Default Configuration
@@ -279,7 +298,8 @@ This is a YAML file that uses all supported configurations and set them as defau
         - name: temperature/*
           type: temperature/types/*
           qos:
-            reliability: true
+            max-rx-rate: 5
+            downsampling: 1
 
       builtin-topics:
         - name: "HelloWorldTopic"
@@ -304,3 +324,5 @@ This is a YAML file that uses all supported configurations and set them as defau
       threads: 12
       max-history-depth: 5000
       discovery-time: 1000
+      max-rx-rate: 10
+      downsampling: 2

--- a/fastddsspy_participants/test/blackbox/model/EndpointDatabaseTest.cpp
+++ b/fastddsspy_participants/test/blackbox/model/EndpointDatabaseTest.cpp
@@ -17,6 +17,7 @@
 
 #include <fastddsspy_participants/participant/SpyParticipant.hpp>
 
+#include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
 #include <ddspipe_core/core/DdsPipe.hpp>
 #include <ddspipe_core/efficiency/payload/FastPayloadPool.hpp>
 #include <ddspipe_core/testing/random_values.hpp>
@@ -106,30 +107,24 @@ std::shared_ptr<DdsPipe> create_pipe(
         dds_participant
         );
 
-    // Create allowed topics list
-    std::set<utils::Heritable<types::IFilterTopic>> lists = {};
-    std::shared_ptr<AllowedTopicList> allowed_topics =
-            std::make_shared<AllowedTopicList>(
-        lists,
-        lists);
-
     // Create Thread Pool
     unsigned int n_threads = 12;
     std::shared_ptr<utils::SlotThreadPool> thread_pool =
             std::make_shared<utils::SlotThreadPool>(n_threads);
 
     // Create DDS Pipe
-    std::set<utils::Heritable<types::DistributedTopic>> builtin_topics = {};
+    DdsPipeConfiguration ddspipe_configuration;
+    ddspipe_configuration.init_enabled = true;
+
     std::shared_ptr<DdsPipe> pipe =
             std::make_unique<DdsPipe>(
-        allowed_topics,
+        ddspipe_configuration,
         discovery_database,
         payload_pool,
         participant_database,
-        thread_pool,
-        builtin_topics,
-        true
+        thread_pool
         );
+
     return pipe;
 }
 

--- a/fastddsspy_participants/test/blackbox/model/ParticipantDatabaseTest.cpp
+++ b/fastddsspy_participants/test/blackbox/model/ParticipantDatabaseTest.cpp
@@ -17,6 +17,7 @@
 
 #include <fastddsspy_participants/participant/SpyParticipant.hpp>
 
+#include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
 #include <ddspipe_core/core/DdsPipe.hpp>
 #include <ddspipe_core/efficiency/payload/FastPayloadPool.hpp>
 #include <ddspipe_core/testing/random_values.hpp>
@@ -106,29 +107,22 @@ std::shared_ptr<DdsPipe> create_pipe(
         dds_participant
         );
 
-    // Create allowed topics list
-    std::set<utils::Heritable<types::IFilterTopic>> lists = {};
-    std::shared_ptr<AllowedTopicList> allowed_topics =
-            std::make_shared<AllowedTopicList>(
-        lists,
-        lists);
-
     // Create Thread Pool
     unsigned int n_threads = 12;
     std::shared_ptr<utils::SlotThreadPool> thread_pool =
             std::make_shared<utils::SlotThreadPool>(n_threads);
 
     // Create DDS Pipe
-    std::set<utils::Heritable<types::DistributedTopic>> builtin_topics = {};
+    DdsPipeConfiguration ddspipe_configuration;
+    ddspipe_configuration.init_enabled = true;
+
     std::shared_ptr<DdsPipe> pipe =
             std::make_unique<DdsPipe>(
-        allowed_topics,
+        ddspipe_configuration,
         discovery_database,
         payload_pool,
         participant_database,
-        thread_pool,
-        builtin_topics,
-        true
+        thread_pool
         );
     return pipe;
 }

--- a/fastddsspy_tool/src/cpp/main.cpp
+++ b/fastddsspy_tool/src/cpp/main.cpp
@@ -160,12 +160,7 @@ int main(
                     try
                     {
                         eprosima::spy::yaml::Configuration new_configuration(file_path);
-                        spy.reload_allowed_topics(
-                            std::make_shared<eprosima::ddspipe::core::AllowedTopicList>(
-                                new_configuration.allowlist,
-                                new_configuration.blocklist
-                                )
-                            );
+                        spy.reload_configuration(new_configuration);
                     }
                     catch (const std::exception& e)
                     {
@@ -199,12 +194,7 @@ int main(
                         try
                         {
                             eprosima::spy::yaml::Configuration new_configuration(file_path);
-                            spy.reload_allowed_topics(
-                                std::make_shared<eprosima::ddspipe::core::AllowedTopicList>(
-                                    new_configuration.allowlist,
-                                    new_configuration.blocklist
-                                    )
-                                );
+                            spy.reload_configuration(new_configuration);
                         }
                         catch (const std::exception& e)
                         {

--- a/fastddsspy_tool/src/cpp/tool/Backend.cpp
+++ b/fastddsspy_tool/src/cpp/tool/Backend.cpp
@@ -80,7 +80,8 @@ Backend::~Backend()
     pipe_->disable();
 }
 
-utils::ReturnCode Backend::reload_configuration(const yaml::Configuration& new_configuration)
+utils::ReturnCode Backend::reload_configuration(
+        const yaml::Configuration& new_configuration)
 {
     return pipe_->reload_configuration(new_configuration.ddspipe_configuration);
 }

--- a/fastddsspy_tool/src/cpp/tool/Backend.hpp
+++ b/fastddsspy_tool/src/cpp/tool/Backend.hpp
@@ -46,7 +46,8 @@ public:
 
     ~Backend();
 
-    utils::ReturnCode reload_configuration(const yaml::Configuration& new_configuration);
+    utils::ReturnCode reload_configuration(
+            const yaml::Configuration& new_configuration);
 
     std::shared_ptr<eprosima::spy::participants::SpyModel> model() const noexcept;
 

--- a/fastddsspy_tool/src/cpp/tool/Backend.hpp
+++ b/fastddsspy_tool/src/cpp/tool/Backend.hpp
@@ -46,8 +46,7 @@ public:
 
     ~Backend();
 
-    utils::ReturnCode reload_allowed_topics(
-            const std::shared_ptr<ddspipe::core::AllowedTopicList>& allowed_topics);
+    utils::ReturnCode reload_configuration(const yaml::Configuration& new_configuration);
 
     std::shared_ptr<eprosima::spy::participants::SpyModel> model() const noexcept;
 
@@ -61,9 +60,6 @@ protected:
 
     //! TODO comment
     std::shared_ptr<ddspipe::core::DiscoveryDatabase> discovery_database_;
-
-    //! TODO comment
-    std::shared_ptr<ddspipe::core::AllowedTopicList> allowed_topics_;
 
     //! TODO comment
     std::shared_ptr<eprosima::utils::SlotThreadPool> thread_pool_;

--- a/fastddsspy_tool/src/cpp/tool/Controller.cpp
+++ b/fastddsspy_tool/src/cpp/tool/Controller.cpp
@@ -63,10 +63,9 @@ void Controller::one_shot_run(
     run_command_(input_.parse_as_command(args));
 }
 
-utils::ReturnCode Controller::reload_allowed_topics(
-        const std::shared_ptr<ddspipe::core::AllowedTopicList>& allowed_topics)
+utils::ReturnCode Controller::reload_configuration(const yaml::Configuration& new_configuration)
 {
-    return backend_.reload_allowed_topics(allowed_topics);
+    return backend_.reload_configuration(new_configuration);
 }
 
 void Controller::run_command_(

--- a/fastddsspy_tool/src/cpp/tool/Controller.cpp
+++ b/fastddsspy_tool/src/cpp/tool/Controller.cpp
@@ -63,7 +63,8 @@ void Controller::one_shot_run(
     run_command_(input_.parse_as_command(args));
 }
 
-utils::ReturnCode Controller::reload_configuration(const yaml::Configuration& new_configuration)
+utils::ReturnCode Controller::reload_configuration(
+        const yaml::Configuration& new_configuration)
 {
     return backend_.reload_configuration(new_configuration);
 }

--- a/fastddsspy_tool/src/cpp/tool/Controller.hpp
+++ b/fastddsspy_tool/src/cpp/tool/Controller.hpp
@@ -42,8 +42,8 @@ public:
     void one_shot_run(
             const std::vector<std::string>& args);
 
-    utils::ReturnCode reload_allowed_topics(
-            const std::shared_ptr<ddspipe::core::AllowedTopicList>& allowed_topics);
+    utils::ReturnCode reload_configuration(
+            const yaml::Configuration& new_configuration);
 
 protected:
 

--- a/fastddsspy_tool/test/application/configuration/configuration_basic.yaml
+++ b/fastddsspy_tool/test/application/configuration/configuration_basic.yaml
@@ -1,4 +1,4 @@
-version: 1.0
+version: 2.0
 
 dds:
   domain: 33
@@ -11,5 +11,7 @@ dds:
 
 specs:
   threads: 12
-  max-history-depth: 5000
   discovery-time: 2000
+
+  qos:
+    history-depth: 5000

--- a/fastddsspy_tool/test/application/configuration/configuration_basic.yaml
+++ b/fastddsspy_tool/test/application/configuration/configuration_basic.yaml
@@ -1,12 +1,13 @@
-version: 2.0
-
 dds:
   domain: 33
+
   allowlist:
     - name: "*"
+
   blocklist:
     - name: "topic_name"
       type: "topic_type"
+
   ros2-types: false
 
 specs:

--- a/fastddsspy_tool/test/application/configuration/configuration_discovery_time.yaml
+++ b/fastddsspy_tool/test/application/configuration/configuration_discovery_time.yaml
@@ -1,4 +1,2 @@
-version: 2.0
-
 specs:
   discovery-time: 2000

--- a/fastddsspy_tool/test/application/configuration/configuration_discovery_time.yaml
+++ b/fastddsspy_tool/test/application/configuration/configuration_discovery_time.yaml
@@ -1,4 +1,4 @@
-version: 1.0
+version: 2.0
 
 specs:
   discovery-time: 2000

--- a/fastddsspy_tool/test/application/configuration/configuration_wrong_empty_arg.yaml
+++ b/fastddsspy_tool/test/application/configuration/configuration_wrong_empty_arg.yaml
@@ -1,5 +1,3 @@
-version: 2.0
-
 dds:
   domain:
   allowlist:

--- a/fastddsspy_tool/test/application/configuration/configuration_wrong_empty_arg.yaml
+++ b/fastddsspy_tool/test/application/configuration/configuration_wrong_empty_arg.yaml
@@ -1,4 +1,4 @@
-version: 1.0
+version: 2.0
 
 dds:
   domain:
@@ -7,5 +7,7 @@ dds:
 
 specs:
   threads: 12
-  max-history-depth: 5000
   discovery-time: 2000
+
+  qos:
+    history-depth: 5000

--- a/fastddsspy_tool/test/application/configuration/configuration_wrong_type.yaml
+++ b/fastddsspy_tool/test/application/configuration/configuration_wrong_type.yaml
@@ -1,4 +1,4 @@
-version: 1.0
+version: 2.0
 
 dds:
   domain: "hello"
@@ -7,5 +7,7 @@ dds:
 
 specs:
   threads: 12
-  max-history-depth: 5000
   discovery-time: 2000
+
+  qos:
+    history-depth: 5000

--- a/fastddsspy_tool/test/application/configuration/configuration_wrong_type.yaml
+++ b/fastddsspy_tool/test/application/configuration/configuration_wrong_type.yaml
@@ -1,7 +1,6 @@
-version: 2.0
-
 dds:
   domain: "hello"
+
   allowlist:
     - name: "*"
 

--- a/fastddsspy_yaml/include/fastddsspy_yaml/YamlReaderConfiguration.hpp
+++ b/fastddsspy_yaml/include/fastddsspy_yaml/YamlReaderConfiguration.hpp
@@ -19,6 +19,7 @@
 
 #include <ddspipe_core/types/topic/filter/IFilterTopic.hpp>
 #include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
+#include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
 #include <ddspipe_core/configuration/IConfiguration.hpp>
 
 #include <ddspipe_participants/configuration/SimpleParticipantConfiguration.hpp>
@@ -57,14 +58,12 @@ public:
     virtual bool is_valid(
             utils::Formatter& error_msg) const noexcept override;
 
+    //! DdsPipe configuration
+    ddspipe::core::DdsPipeConfiguration ddspipe_configuration {};
+
     // Participants configurations
     std::shared_ptr<ddspipe::participants::SimpleParticipantConfiguration> simple_configuration;
     std::shared_ptr<participants::SpyParticipantConfiguration> spy_configuration;
-
-    // Topic filtering
-    std::set<utils::Heritable<ddspipe::core::types::IFilterTopic>> allowlist {};
-    std::set<utils::Heritable<ddspipe::core::types::IFilterTopic>> blocklist {};
-    std::set<utils::Heritable<ddspipe::core::types::DistributedTopic>> builtin_topics {};
 
     //! Whether to generate schemas as OMG IDL or ROS2 msg
     bool ros2_types = false;

--- a/fastddsspy_yaml/include/fastddsspy_yaml/YamlReaderConfiguration.hpp
+++ b/fastddsspy_yaml/include/fastddsspy_yaml/YamlReaderConfiguration.hpp
@@ -37,7 +37,7 @@ namespace spy {
 namespace yaml {
 
 /**
- * @brief Class that encapsulates specific methods to get a full ddspipe Configuration from a yaml node.
+ * @brief Class that encapsulates specific methods to get a full FastDdsSpy Configuration from a yaml node.
  */
 class Configuration : ddspipe::core::IConfiguration
 {
@@ -71,6 +71,8 @@ public:
     // Specs
     unsigned int n_threads = 12;
     utils::Duration_ms one_shot_wait_time_ms = 1000;
+    float max_rx_rate = 0;
+    unsigned int downsampling = 1;
 
 protected:
 

--- a/fastddsspy_yaml/include/fastddsspy_yaml/YamlReaderConfiguration.hpp
+++ b/fastddsspy_yaml/include/fastddsspy_yaml/YamlReaderConfiguration.hpp
@@ -17,6 +17,7 @@
 #include <cpp_utils/memory/Heritable.hpp>
 #include <cpp_utils/time/time_utils.hpp>
 
+#include <ddspipe_core/types/dds/TopicQoS.hpp>
 #include <ddspipe_core/types/topic/filter/IFilterTopic.hpp>
 #include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
 #include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
@@ -71,8 +72,7 @@ public:
     // Specs
     unsigned int n_threads = 12;
     utils::Duration_ms one_shot_wait_time_ms = 1000;
-    float max_rx_rate = 0;
-    unsigned int downsampling = 1;
+    ddspipe::core::types::TopicQoS topic_qos{};
 
 protected:
 

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -16,6 +16,7 @@
 #include <ddspipe_core/types/dynamic_types/types.hpp>
 #include <ddspipe_core/types/topic/dds/DdsTopic.hpp>
 #include <ddspipe_core/types/topic/filter/IFilterTopic.hpp>
+#include <ddspipe_core/types/topic/filter/ManualTopic.hpp>
 #include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 #include <ddspipe_participants/types/address/Address.hpp>
 
@@ -140,13 +141,9 @@ void Configuration::load_dds_configuration_(
     // Get optional topics
     if (YamlReader::is_tag_present(yml, TOPICS_TAG))
     {
-        auto manual_topics = YamlReader::get_list<WildcardDdsFilterTopic>(yml, TOPICS_TAG, version);
-
-        for (auto const& manual_topic : manual_topics)
-        {
-            auto new_topic = utils::Heritable<WildcardDdsFilterTopic>::make_heritable(manual_topic);
-            ddspipe_configuration.manual_topics.push_back(new_topic);
-        }
+        const auto& manual_topics = YamlReader::get_list<ManualTopic>(yml, TOPICS_TAG, version);
+        ddspipe_configuration.manual_topics =
+                std::vector<ManualTopic>(manual_topics.begin(), manual_topics.end());
     }
 
     /////

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -227,6 +227,28 @@ void Configuration::load_specs_configuration_(
     {
         one_shot_wait_time_ms = YamlReader::get<utils::Duration_ms>(yml, GATHERING_TIME_TAG, version);
     }
+
+    /////
+    // Get optional max reception rate
+    if (YamlReader::is_tag_present(yml, MAX_RX_RATE_TAG))
+    {
+        // Save max reception rate
+        max_rx_rate = YamlReader::get_nonnegative_float(yml, MAX_RX_RATE_TAG);
+
+        // Set default value for max reception rate
+        TopicQoS::default_max_rx_rate.store(max_rx_rate);
+    }
+
+    /////
+    // Get optional downsampling
+    if (YamlReader::is_tag_present(yml, DOWNSAMPLING_TAG))
+    {
+        // Save downsampling factor
+        downsampling = YamlReader::get_positive_int(yml, DOWNSAMPLING_TAG);
+
+        // Set default value for downsampling
+        TopicQoS::default_downsampling.store(downsampling);
+    }
 }
 
 bool Configuration::is_valid(

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -96,9 +96,10 @@ void Configuration::load_configuration_(
         WildcardDdsFilterTopic rpc_request_topic, rpc_response_topic;
         rpc_request_topic.topic_name.set_value("rq/*");
         rpc_response_topic.topic_name.set_value("rr/*");
-        blocklist.insert(
+
+        ddspipe_configuration.blocklist.insert(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_request_topic));
-        blocklist.insert(
+        ddspipe_configuration.blocklist.insert(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_response_topic));
 
     }
@@ -117,13 +118,13 @@ void Configuration::load_dds_configuration_(
     // Get optional allowlist
     if (YamlReader::is_tag_present(yml, ALLOWLIST_TAG))
     {
-        allowlist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, ALLOWLIST_TAG,
+        ddspipe_configuration.allowlist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, ALLOWLIST_TAG,
                         version);
 
         // Add to allowlist always the type object topic
         WildcardDdsFilterTopic internal_topic;
         internal_topic.topic_name.set_value(TYPE_OBJECT_TOPIC_NAME);
-        allowlist.insert(
+        ddspipe_configuration.allowlist.insert(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(internal_topic));
     }
 
@@ -131,7 +132,7 @@ void Configuration::load_dds_configuration_(
     // Get optional blocklist
     if (YamlReader::is_tag_present(yml, BLOCKLIST_TAG))
     {
-        blocklist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, BLOCKLIST_TAG,
+        ddspipe_configuration.blocklist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, BLOCKLIST_TAG,
                         version);
     }
 
@@ -139,8 +140,7 @@ void Configuration::load_dds_configuration_(
     // Get optional builtin topics
     if (YamlReader::is_tag_present(yml, BUILTIN_TAG))
     {
-        // WARNING: Parse builtin topics AFTER specs, as some topic-specific default values are set there
-        builtin_topics = YamlReader::get_set<utils::Heritable<DistributedTopic>>(yml, BUILTIN_TAG,
+        ddspipe_configuration.builtin_topics = YamlReader::get_set<utils::Heritable<DistributedTopic>>(yml, BUILTIN_TAG,
                         version);
     }
 

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -72,7 +72,6 @@ void Configuration::load_configuration_(
 
         /////
         // Get optional specs configuration options
-        // WARNING: Parse builtin topics (dds tag) AFTER specs, as some topic-specific default values are set there
         if (YamlReader::is_tag_present(yml, SPECS_TAG))
         {
             auto specs_yml = YamlReader::get_value_in_tag(yml, SPECS_TAG);
@@ -144,14 +143,6 @@ void Configuration::load_dds_configuration_(
         const auto& manual_topics = YamlReader::get_list<ManualTopic>(yml, TOPICS_TAG, version);
         ddspipe_configuration.manual_topics =
                 std::vector<ManualTopic>(manual_topics.begin(), manual_topics.end());
-    }
-
-    /////
-    // Get optional builtin topics
-    if (YamlReader::is_tag_present(yml, BUILTIN_TAG))
-    {
-        ddspipe_configuration.builtin_topics = YamlReader::get_set<utils::Heritable<DistributedTopic>>(yml, BUILTIN_TAG,
-                        version);
     }
 
     // Set the domain in Simple Participant Configuration

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -137,6 +137,19 @@ void Configuration::load_dds_configuration_(
     }
 
     /////
+    // Get optional topics
+    if (YamlReader::is_tag_present(yml, TOPICS_TAG))
+    {
+        auto manual_topics = YamlReader::get_list<WildcardDdsFilterTopic>(yml, TOPICS_TAG, version);
+
+        for (auto const& manual_topic : manual_topics)
+        {
+            auto new_topic = utils::Heritable<WildcardDdsFilterTopic>::make_heritable(manual_topic);
+            ddspipe_configuration.manual_topics.push_back(new_topic);
+        }
+    }
+
+    /////
     // Get optional builtin topics
     if (YamlReader::is_tag_present(yml, BUILTIN_TAG))
     {

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -213,41 +213,18 @@ void Configuration::load_specs_configuration_(
         n_threads = YamlReader::get<unsigned int>(yml, NUMBER_THREADS_TAG, version);
     }
 
-    // Get optional maximum history depth
-    if (YamlReader::is_tag_present(yml, MAX_HISTORY_DEPTH_TAG))
+    /////
+    // Get optional Topic QoS
+    if (YamlReader::is_tag_present(yml, SPECS_QOS_TAG))
     {
-        TopicQoS::default_history_depth = YamlReader::get<unsigned int>(
-            yml,
-            MAX_HISTORY_DEPTH_TAG,
-            version);
+        YamlReader::fill<TopicQoS>(topic_qos, YamlReader::get_value_in_tag(yml, SPECS_QOS_TAG), version);
+        TopicQoS::default_topic_qos.set_value(topic_qos);
     }
 
     // Get optional gathering time
     if (YamlReader::is_tag_present(yml, GATHERING_TIME_TAG))
     {
         one_shot_wait_time_ms = YamlReader::get<utils::Duration_ms>(yml, GATHERING_TIME_TAG, version);
-    }
-
-    /////
-    // Get optional max reception rate
-    if (YamlReader::is_tag_present(yml, MAX_RX_RATE_TAG))
-    {
-        // Save max reception rate
-        max_rx_rate = YamlReader::get_nonnegative_float(yml, MAX_RX_RATE_TAG);
-
-        // Set default value for max reception rate
-        TopicQoS::default_max_rx_rate.store(max_rx_rate);
-    }
-
-    /////
-    // Get optional downsampling
-    if (YamlReader::is_tag_present(yml, DOWNSAMPLING_TAG))
-    {
-        // Save downsampling factor
-        downsampling = YamlReader::get_positive_int(yml, DOWNSAMPLING_TAG);
-
-        // Set default value for downsampling
-        TopicQoS::default_downsampling.store(downsampling);
     }
 }
 

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -3,7 +3,7 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
-version: 2
+version: 2.0
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -2,9 +2,6 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
-version: 2.0
-
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/resources/fastddsspy_configuration.yaml
+++ b/resources/fastddsspy_configuration.yaml
@@ -15,4 +15,6 @@ dds:
 
 specs:
   threads: 12
-  max-history-depth: 5000
+
+  qos:
+    history-depth: 5000


### PR DESCRIPTION
In this version, topics' QoS are configurable. The set of predefined topics' QoS takes precedence over the discovered topics' QoS.

The following features have also been implemented:
- max-rx-rate (max reception rate): the processing frequency for received samples.
- downsampling: the proportion of samples to process for received samples.

These features can be configured generically, per participant, and per topic.

Merge after:
- https://github.com/eProsima/DDS-Router/pull/391
- https://github.com/eProsima/DDS-Pipe/pull/64