### PR TITLE
Make the trigger of the DDS Pipe callbacks configurable

### DIFF
--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -243,10 +243,6 @@ Example:
 
 See `Interface Whitelist <https://fast-dds.docs.eprosima.com/en/latest/fastdds/transport/whitelist.html>`_ for more information.
 
-.. warning::
-
-    When providing an interface whitelist, external participants with which communication is desired must also be configured with interface whitelisting.
-
 Topic type format
 -----------------
 

--- a/fastddsspy_participants/include/fastddsspy_participants/types/EndpointInfo.hpp
+++ b/fastddsspy_participants/include/fastddsspy_participants/types/EndpointInfo.hpp
@@ -40,6 +40,7 @@ struct EndpointInfoData : public ddspipe::core::IRoutingData
     EndpointInfo info{};
 };
 
+FASTDDSSPY_PARTICIPANTS_DllAPI
 ddspipe::core::types::DdsTopic endpoint_info_topic() noexcept;
 
 FASTDDSSPY_PARTICIPANTS_DllAPI

--- a/fastddsspy_participants/include/fastddsspy_participants/types/ParticipantInfo.hpp
+++ b/fastddsspy_participants/include/fastddsspy_participants/types/ParticipantInfo.hpp
@@ -52,6 +52,7 @@ struct ParticipantInfoData : public ddspipe::core::IRoutingData
     ParticipantInfo info{};
 };
 
+FASTDDSSPY_PARTICIPANTS_DllAPI
 ddspipe::core::types::DdsTopic participant_info_topic() noexcept;
 
 FASTDDSSPY_PARTICIPANTS_DllAPI

--- a/fastddsspy_participants/src/cpp/participant/SpyParticipant.cpp
+++ b/fastddsspy_participants/src/cpp/participant/SpyParticipant.cpp
@@ -35,6 +35,7 @@ SpyParticipant::SpyParticipant(
             {
                 return this->new_participant_info_(data);
             };
+
     participants_writer_ = std::make_shared<InternalWriter>(
         participant_configuration->id,
         participant_callback);
@@ -43,19 +44,10 @@ SpyParticipant::SpyParticipant(
             {
                 return this->new_endpoint_info_(data);
             };
+
     endpoints_writer_ = std::make_shared<InternalWriter>(
         participant_configuration->id,
         endpoint_callback);
-
-    // Simulate that there is a reader of participants to force this track creation
-    discovery_database_->add_endpoint(
-        ddspipe::participants::rtps::CommonParticipant::simulate_endpoint(participant_info_topic(), this->id())
-        );
-
-    // Simulate that there is a reader of endpoints to force this track creation
-    discovery_database_->add_endpoint(
-        ddspipe::participants::rtps::CommonParticipant::simulate_endpoint(endpoint_info_topic(), this->id())
-        );
 }
 
 std::shared_ptr<ddspipe::core::IWriter> SpyParticipant::create_writer(

--- a/fastddsspy_participants/test/blackbox/model/EndpointDatabaseTest.cpp
+++ b/fastddsspy_participants/test/blackbox/model/EndpointDatabaseTest.cpp
@@ -116,6 +116,11 @@ std::shared_ptr<DdsPipe> create_pipe(
     DdsPipeConfiguration ddspipe_configuration;
     ddspipe_configuration.init_enabled = true;
 
+    // Create the internal communication (built-in) topics
+    ddspipe_configuration.builtin_topics.insert(
+        utils::Heritable<types::DistributedTopic>::make_heritable(
+            spy::participants::endpoint_info_topic()));
+
     std::shared_ptr<DdsPipe> pipe =
             std::make_unique<DdsPipe>(
         ddspipe_configuration,

--- a/fastddsspy_participants/test/blackbox/model/EndpointDatabaseTest.cpp
+++ b/fastddsspy_participants/test/blackbox/model/EndpointDatabaseTest.cpp
@@ -116,7 +116,7 @@ std::shared_ptr<DdsPipe> create_pipe(
     DdsPipeConfiguration ddspipe_configuration;
     ddspipe_configuration.init_enabled = true;
 
-    // Create the internal communication (built-in) topics
+    // Create a built-in topic to transmit endpoint information
     ddspipe_configuration.builtin_topics.insert(
         utils::Heritable<types::DistributedTopic>::make_heritable(
             spy::participants::endpoint_info_topic()));

--- a/fastddsspy_participants/test/blackbox/model/EndpointDatabaseTest.cpp
+++ b/fastddsspy_participants/test/blackbox/model/EndpointDatabaseTest.cpp
@@ -122,8 +122,7 @@ std::shared_ptr<DdsPipe> create_pipe(
         discovery_database,
         payload_pool,
         participant_database,
-        thread_pool
-        );
+        thread_pool);
 
     return pipe;
 }

--- a/fastddsspy_participants/test/blackbox/model/ParticipantDatabaseTest.cpp
+++ b/fastddsspy_participants/test/blackbox/model/ParticipantDatabaseTest.cpp
@@ -117,7 +117,7 @@ std::shared_ptr<DdsPipe> create_pipe(
     DdsPipeConfiguration ddspipe_configuration;
     ddspipe_configuration.init_enabled = true;
 
-    // Create the internal communication (built-in) topics
+    // Create a built-in topic to transmit participant information
     ddspipe_configuration.builtin_topics.insert(
         utils::Heritable<types::DistributedTopic>::make_heritable(
             spy::participants::participant_info_topic()));

--- a/fastddsspy_participants/test/blackbox/model/ParticipantDatabaseTest.cpp
+++ b/fastddsspy_participants/test/blackbox/model/ParticipantDatabaseTest.cpp
@@ -90,6 +90,7 @@ std::shared_ptr<DdsPipe> create_pipe(
     // Create participants
     std::shared_ptr<spy::participants::SpyParticipantConfiguration> spy_configuration =
             std::make_shared<spy::participants::SpyParticipantConfiguration>();
+
     std::shared_ptr<spy::participants::SpyParticipant> spy_participant =
             std::make_shared<spy::participants::SpyParticipant>(
         spy_configuration,
@@ -115,6 +116,11 @@ std::shared_ptr<DdsPipe> create_pipe(
     // Create DDS Pipe
     DdsPipeConfiguration ddspipe_configuration;
     ddspipe_configuration.init_enabled = true;
+
+    // Create the internal communication (built-in) topics
+    ddspipe_configuration.builtin_topics.insert(
+        utils::Heritable<types::DistributedTopic>::make_heritable(
+            spy::participants::participant_info_topic()));
 
     std::shared_ptr<DdsPipe> pipe =
             std::make_unique<DdsPipe>(

--- a/fastddsspy_participants/test/blackbox/model/ParticipantDatabaseTest.cpp
+++ b/fastddsspy_participants/test/blackbox/model/ParticipantDatabaseTest.cpp
@@ -122,8 +122,8 @@ std::shared_ptr<DdsPipe> create_pipe(
         discovery_database,
         payload_pool,
         participant_database,
-        thread_pool
-        );
+        thread_pool);
+
     return pipe;
 }
 

--- a/fastddsspy_tool/src/cpp/tool/Backend.cpp
+++ b/fastddsspy_tool/src/cpp/tool/Backend.cpp
@@ -62,9 +62,18 @@ Backend::Backend(
         spy_participant_
         );
 
+    // Create the internal communication (built-in) topics
+    configuration_.ddspipe_configuration.builtin_topics.insert(
+        utils::Heritable<eprosima::ddspipe::core::types::DistributedTopic>::make_heritable(
+            spy::participants::participant_info_topic()));
+
+    configuration_.ddspipe_configuration.builtin_topics.insert(
+        utils::Heritable<eprosima::ddspipe::core::types::DistributedTopic>::make_heritable(
+            spy::participants::endpoint_info_topic()));
+
     // Create and initialize Pipe
     pipe_ = std::make_unique<ddspipe::core::DdsPipe>(
-        configuration.ddspipe_configuration,
+        configuration_.ddspipe_configuration,
         discovery_database_,
         payload_pool_,
         participant_database_,

--- a/fastddsspy_tool/src/cpp/tool/Backend.cpp
+++ b/fastddsspy_tool/src/cpp/tool/Backend.cpp
@@ -66,7 +66,7 @@ Backend::Backend(
     ddspipe::core::DdsPipeConfiguration ddspipe_configuration;
 
     pipe_ = std::make_unique<ddspipe::core::DdsPipe>(
-        ddspipe_configuration,
+        configuration.ddspipe_configuration,
         discovery_database_,
         payload_pool_,
         participant_database_,

--- a/fastddsspy_tool/src/cpp/tool/Backend.cpp
+++ b/fastddsspy_tool/src/cpp/tool/Backend.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
+#include <ddspipe_core/types/dynamic_types/types.hpp>
 
 #include "Backend.hpp"
 
@@ -71,6 +72,11 @@ Backend::Backend(
     configuration_.ddspipe_configuration.builtin_topics.insert(
         utils::Heritable<eprosima::ddspipe::core::types::DistributedTopic>::make_heritable(
             spy::participants::endpoint_info_topic()));
+
+    // Create an internal topic to transmit the dynamic types
+    configuration_.ddspipe_configuration.builtin_topics.insert(
+        utils::Heritable<eprosima::ddspipe::core::types::DistributedTopic>::make_heritable(
+            eprosima::ddspipe::core::types::type_object_topic()));
 
     // Create and initialize Pipe
     pipe_ = std::make_unique<ddspipe::core::DdsPipe>(

--- a/fastddsspy_tool/src/cpp/tool/Backend.cpp
+++ b/fastddsspy_tool/src/cpp/tool/Backend.cpp
@@ -62,11 +62,12 @@ Backend::Backend(
         spy_participant_
         );
 
-    // Create the internal communication (built-in) topics
+    // Create a built-in topic to transmit participant information
     configuration_.ddspipe_configuration.builtin_topics.insert(
         utils::Heritable<eprosima::ddspipe::core::types::DistributedTopic>::make_heritable(
             spy::participants::participant_info_topic()));
 
+    // Create a built-in topic to transmit endpoint information
     configuration_.ddspipe_configuration.builtin_topics.insert(
         utils::Heritable<eprosima::ddspipe::core::types::DistributedTopic>::make_heritable(
             spy::participants::endpoint_info_topic()));

--- a/fastddsspy_tool/src/cpp/tool/Backend.cpp
+++ b/fastddsspy_tool/src/cpp/tool/Backend.cpp
@@ -78,6 +78,31 @@ Backend::Backend(
         utils::Heritable<eprosima::ddspipe::core::types::DistributedTopic>::make_heritable(
             eprosima::ddspipe::core::types::type_object_topic()));
 
+    if (!configuration_.ddspipe_configuration.allowlist.empty())
+    {
+        // The allowlist is not empty. Add the internal topics.
+        eprosima::ddspipe::core::types::WildcardDdsFilterTopic type_object_topic;
+        type_object_topic.topic_name.set_value(eprosima::ddspipe::core::types::TYPE_OBJECT_TOPIC_NAME);
+
+        configuration_.ddspipe_configuration.allowlist.insert(
+            utils::Heritable<eprosima::ddspipe::core::types::WildcardDdsFilterTopic>::make_heritable(
+                type_object_topic));
+
+        eprosima::ddspipe::core::types::WildcardDdsFilterTopic participant_info_topic;
+        participant_info_topic.topic_name.set_value(participants::PARTICIPANT_INFO_TOPIC_NAME);
+
+        configuration_.ddspipe_configuration.allowlist.insert(
+            utils::Heritable<eprosima::ddspipe::core::types::WildcardDdsFilterTopic>::make_heritable(
+                participant_info_topic));
+
+        eprosima::ddspipe::core::types::WildcardDdsFilterTopic endpoint_info_topic;
+        endpoint_info_topic.topic_name.set_value(participants::ENDPOINT_INFO_TOPIC_NAME);
+
+        configuration_.ddspipe_configuration.allowlist.insert(
+            utils::Heritable<eprosima::ddspipe::core::types::WildcardDdsFilterTopic>::make_heritable(
+                endpoint_info_topic));
+    }
+
     // Create and initialize Pipe
     pipe_ = std::make_unique<ddspipe::core::DdsPipe>(
         configuration_.ddspipe_configuration,

--- a/fastddsspy_tool/src/cpp/tool/Backend.cpp
+++ b/fastddsspy_tool/src/cpp/tool/Backend.cpp
@@ -63,8 +63,6 @@ Backend::Backend(
         );
 
     // Create and initialize Pipe
-    ddspipe::core::DdsPipeConfiguration ddspipe_configuration;
-
     pipe_ = std::make_unique<ddspipe::core::DdsPipe>(
         configuration.ddspipe_configuration,
         discovery_database_,

--- a/fastddsspy_yaml/include/fastddsspy_yaml/YamlReaderConfiguration.hpp
+++ b/fastddsspy_yaml/include/fastddsspy_yaml/YamlReaderConfiguration.hpp
@@ -17,11 +17,10 @@
 #include <cpp_utils/memory/Heritable.hpp>
 #include <cpp_utils/time/time_utils.hpp>
 
-#include <ddspipe_core/types/dds/TopicQoS.hpp>
-#include <ddspipe_core/types/topic/filter/IFilterTopic.hpp>
-#include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
 #include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
 #include <ddspipe_core/configuration/IConfiguration.hpp>
+#include <ddspipe_core/types/topic/filter/IFilterTopic.hpp>
+#include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
 
 #include <ddspipe_participants/configuration/SimpleParticipantConfiguration.hpp>
 #include <ddspipe_participants/configuration/ParticipantConfiguration.hpp>
@@ -30,6 +29,8 @@
 #include <ddspipe_yaml/YamlReader.hpp>
 
 #include <fastddsspy_participants/configuration/SpyParticipantConfiguration.hpp>
+#include <fastddsspy_participants/types/EndpointInfo.hpp>
+#include <fastddsspy_participants/types/ParticipantInfo.hpp>
 
 #include <fastddsspy_yaml/library/library_dll.h>
 

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -103,10 +103,7 @@ void Configuration::load_configuration_(
         WildcardDdsFilterTopic rpc_request_topic, rpc_response_topic;
         rpc_request_topic.topic_name.set_value("rq/*");
         rpc_response_topic.topic_name.set_value("rr/*");
-<<<<<<< HEAD
 
-=======
->>>>>>> 4c906f4 (Make the DdsPipeConfiguration required)
         ddspipe_configuration.blocklist.insert(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_request_topic));
         ddspipe_configuration.blocklist.insert(

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -124,24 +124,6 @@ void Configuration::load_dds_configuration_(
     {
         ddspipe_configuration.allowlist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, ALLOWLIST_TAG,
                         version);
-
-        // Add to allowlist always the type object topic
-        WildcardDdsFilterTopic type_object_topic;
-        type_object_topic.topic_name.set_value(TYPE_OBJECT_TOPIC_NAME);
-        ddspipe_configuration.allowlist.insert(
-            utils::Heritable<WildcardDdsFilterTopic>::make_heritable(type_object_topic));
-
-        // Add to allowlist always the participant info internal topic
-        WildcardDdsFilterTopic participant_info_topic;
-        participant_info_topic.topic_name.set_value(participants::PARTICIPANT_INFO_TOPIC_NAME);
-        ddspipe_configuration.allowlist.insert(
-            utils::Heritable<WildcardDdsFilterTopic>::make_heritable(participant_info_topic));
-
-        // Add to allowlist always the endpoint info internal topic
-        WildcardDdsFilterTopic endpoint_info_topic;
-        endpoint_info_topic.topic_name.set_value(participants::ENDPOINT_INFO_TOPIC_NAME);
-        ddspipe_configuration.allowlist.insert(
-            utils::Heritable<WildcardDdsFilterTopic>::make_heritable(endpoint_info_topic));
     }
 
     /////

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -164,6 +164,15 @@ void Configuration::load_dds_configuration_(
                 std::vector<ManualTopic>(manual_topics.begin(), manual_topics.end());
     }
 
+    // Create the internal communication (built-in) topics
+    const auto& participant_internal_topic = utils::Heritable<DistributedTopic>::make_heritable(
+            spy::participants::participant_info_topic());
+    const auto& endpoint_internal_topic = utils::Heritable<DistributedTopic>::make_heritable(
+            spy::participants::endpoint_info_topic());
+
+    ddspipe_configuration.builtin_topics.insert(participant_internal_topic);
+    ddspipe_configuration.builtin_topics.insert(endpoint_internal_topic);
+
     // Set the domain in Simple Participant Configuration
     if (YamlReader::is_tag_present(yml, DOMAIN_ID_TAG))
     {

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -105,6 +105,7 @@ void Configuration::load_configuration_(
         ddspipe_configuration.blocklist.insert(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_response_topic));
 
+        // Only trigger the DdsPipe's callbacks with the discovery (and removal) of writers.
         ddspipe_configuration.discovery_trigger = DiscoveryTrigger::WRITER;
     }
     catch (const std::exception& e)

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -15,7 +15,6 @@
 #include <ddspipe_core/types/dds/TopicQoS.hpp>
 #include <ddspipe_core/types/dynamic_types/types.hpp>
 #include <ddspipe_core/types/topic/dds/DdsTopic.hpp>
-#include <ddspipe_core/types/topic/filter/IFilterTopic.hpp>
 #include <ddspipe_core/types/topic/filter/ManualTopic.hpp>
 #include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 #include <ddspipe_participants/types/address/Address.hpp>
@@ -24,9 +23,6 @@
 #include <ddspipe_yaml/Yaml.hpp>
 #include <ddspipe_yaml/YamlManager.hpp>
 #include <ddspipe_yaml/YamlReader.hpp>
-
-#include <fastddsspy_participants/types/EndpointInfo.hpp>
-#include <fastddsspy_participants/types/ParticipantInfo.hpp>
 
 #include <fastddsspy_yaml/yaml_configuration_tags.hpp>
 
@@ -109,6 +105,7 @@ void Configuration::load_configuration_(
         ddspipe_configuration.blocklist.insert(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_response_topic));
 
+        ddspipe_configuration.discovery_trigger = DiscoveryTrigger::WRITER;
     }
     catch (const std::exception& e)
     {
@@ -163,15 +160,6 @@ void Configuration::load_dds_configuration_(
         ddspipe_configuration.manual_topics =
                 std::vector<ManualTopic>(manual_topics.begin(), manual_topics.end());
     }
-
-    // Create the internal communication (built-in) topics
-    const auto& participant_internal_topic = utils::Heritable<DistributedTopic>::make_heritable(
-        spy::participants::participant_info_topic());
-    const auto& endpoint_internal_topic = utils::Heritable<DistributedTopic>::make_heritable(
-        spy::participants::endpoint_info_topic());
-
-    ddspipe_configuration.builtin_topics.insert(participant_internal_topic);
-    ddspipe_configuration.builtin_topics.insert(endpoint_internal_topic);
 
     // Set the domain in Simple Participant Configuration
     if (YamlReader::is_tag_present(yml, DOMAIN_ID_TAG))

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -166,9 +166,9 @@ void Configuration::load_dds_configuration_(
 
     // Create the internal communication (built-in) topics
     const auto& participant_internal_topic = utils::Heritable<DistributedTopic>::make_heritable(
-            spy::participants::participant_info_topic());
+        spy::participants::participant_info_topic());
     const auto& endpoint_internal_topic = utils::Heritable<DistributedTopic>::make_heritable(
-            spy::participants::endpoint_info_topic());
+        spy::participants::endpoint_info_topic());
 
     ddspipe_configuration.builtin_topics.insert(participant_internal_topic);
     ddspipe_configuration.builtin_topics.insert(endpoint_internal_topic);

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -103,7 +103,10 @@ void Configuration::load_configuration_(
         WildcardDdsFilterTopic rpc_request_topic, rpc_response_topic;
         rpc_request_topic.topic_name.set_value("rq/*");
         rpc_response_topic.topic_name.set_value("rr/*");
+<<<<<<< HEAD
 
+=======
+>>>>>>> 4c906f4 (Make the DdsPipeConfiguration required)
         ddspipe_configuration.blocklist.insert(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_request_topic));
         ddspipe_configuration.blocklist.insert(


### PR DESCRIPTION
In the previous version, the DDS Pipe's callbacks were only triggered by the discovery of readers, so the Fast-DDS-spy had to simulate the creation of a reader to trigger the creation of the Bridge. In this version, the entity type that triggers the callbacks is configurable, so the Fast-DDS-spy can trigger them with the discovery of writers.

Merge after:
- https://github.com/eProsima/DDS-Record-Replay/pull/86
- https://github.com/eProsima/DDS-Pipe/pull/67