### PR TITLE
Add app_id and app_metadata attributes

### DIFF
--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -14,3 +14,4 @@ This release will include the following **Configuration features**:
 * :ref:`Max Reception Rate <user_manual_configuration_dds__max_rx_rate>`.
 * :ref:`Downsampling <user_manual_configuration_dds__downsampling>`.
 * Remove the support for Built-in Topics.
+* Store `app_id` and `app_metadata` attributes in  *eProsima Fast DDS Spy* participants.

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -14,4 +14,4 @@ This release will include the following **Configuration features**:
 * :ref:`Max Reception Rate <user_manual_configuration_dds__max_rx_rate>`.
 * :ref:`Downsampling <user_manual_configuration_dds__downsampling>`.
 * Remove the support for Built-in Topics.
-* Store `app_id` and `app_metadata` attributes in  *eProsima Fast DDS Spy* participants.
+* Set `app_id` and `app_metadata` attributes in  *eProsima Fast DDS Spy* participants.

--- a/docs/rst/notes/notes.rst
+++ b/docs/rst/notes/notes.rst
@@ -2,6 +2,7 @@
 
 .. _notes:
 
+.. TODO uncomment when there are forthcoming notes
 .. include:: forthcoming_version.rst
 
 ##############

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -47,8 +47,12 @@ Configuration::Configuration()
     , spy_configuration(std::make_shared<participants::SpyParticipantConfiguration>())
 {
     simple_configuration->id = "SimpleParticipant";
+    simple_configuration->id = "RecorderRecorderParticipant";
+    simple_configuration->app_id = "FASTDDS SPY";
     simple_configuration->is_repeater = false;
     spy_configuration->id = "Fast-Spy-007";
+    simple_configuration->id = "RecorderRecorderParticipant";
+    simple_configuration->app_id = "FASTDDS SPY";
     spy_configuration->is_repeater = false;
 }
 

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -47,12 +47,12 @@ Configuration::Configuration()
     , spy_configuration(std::make_shared<participants::SpyParticipantConfiguration>())
 {
     simple_configuration->id = "SimpleParticipant";
-    simple_configuration->id = "RecorderRecorderParticipant";
-    simple_configuration->app_id = "FASTDDS SPY";
+    simple_configuration->app_id = "FASTDDS_SPY";
+    simple_configuration->app_metadata = "";
     simple_configuration->is_repeater = false;
     spy_configuration->id = "Fast-Spy-007";
-    simple_configuration->id = "RecorderRecorderParticipant";
-    simple_configuration->app_id = "FASTDDS SPY";
+    spy_configuration->app_id = "FASTDDS_SPY";
+    spy_configuration->app_metadata = "";
     spy_configuration->is_repeater = false;
 }
 

--- a/fastddsspy_yaml/test/unittest/yaml_reader/CMakeLists.txt
+++ b/fastddsspy_yaml/test/unittest/yaml_reader/CMakeLists.txt
@@ -12,9 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-##############
-# Yaml Tests #
-##############
+############################
+# Yaml Reader Test         #
+############################
 
-add_subdirectory(yaml_writer)
-add_subdirectory(yaml_reader)
+set(TEST_NAME YamlReaderTest)
+
+set(TEST_SOURCES
+        ${PROJECT_SOURCE_DIR}/src/cpp/YamlReaderConfiguration.cpp
+        YamlReaderTest.cpp
+    )
+
+set(TEST_LIST
+        get_spy_configuration_trivial
+    )
+
+set(TEST_EXTRA_LIBRARIES
+        ${MODULE_DEPENDENCIES}
+    )
+
+add_unittest_executable(
+    "${TEST_NAME}"
+    "${TEST_SOURCES}"
+    "${TEST_LIST}"
+    "${TEST_EXTRA_LIBRARIES}")

--- a/fastddsspy_yaml/test/unittest/yaml_reader/YamlReaderTest.cpp
+++ b/fastddsspy_yaml/test/unittest/yaml_reader/YamlReaderTest.cpp
@@ -1,0 +1,66 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cpp_utils/testing/gtest_aux.hpp>
+#include <gtest/gtest.h>
+
+#include <fastddsspy_yaml/YamlReaderConfiguration.hpp>
+
+using namespace eprosima;
+using namespace eprosima::ddspipe::yaml;
+using namespace eprosima::spy::participants;
+
+/**
+ * Test load a whole Spy Configuration from yaml node.
+ */
+TEST(YamlReaderTest, get_spy_configuration_trivial)
+{
+    const char* yml_str =
+            R"(
+            version: v4.0
+            dds:
+                ros2-types: true
+        )";
+
+    Yaml yml = YAML::Load(yml_str);
+
+    // Load configuration
+    eprosima::spy::yaml::Configuration configuration(yml);
+
+    // Check is valid
+    utils::Formatter error_msg;
+    ASSERT_TRUE(configuration.is_valid(error_msg));
+
+    // Check yaml specified data
+    ASSERT_EQ(configuration.ros2_types, true);
+
+    // Check app data
+    ASSERT_EQ(configuration.simple_configuration->id, "SimpleParticipant");
+    ASSERT_EQ(configuration.simple_configuration->app_id, "FASTDDS_SPY");
+    ASSERT_EQ(configuration.simple_configuration->app_metadata, "");
+    ASSERT_EQ(configuration.simple_configuration->is_repeater, false);
+
+    ASSERT_EQ(configuration.spy_configuration->id, "Fast-Spy-007");
+    ASSERT_EQ(configuration.spy_configuration->app_id, "FASTDDS_SPY");
+    ASSERT_EQ(configuration.spy_configuration->app_metadata, "");
+    ASSERT_EQ(configuration.spy_configuration->is_repeater, false);
+}
+
+int main(
+        int argc,
+        char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/fastddsspy_yaml/test/unittest/yaml_reader/YamlReaderTest.cpp
+++ b/fastddsspy_yaml/test/unittest/yaml_reader/YamlReaderTest.cpp
@@ -49,12 +49,12 @@ TEST(YamlReaderTest, get_spy_configuration_trivial)
     ASSERT_EQ(configuration.simple_configuration->id, "SimpleParticipant");
     ASSERT_EQ(configuration.simple_configuration->app_id, "FASTDDS_SPY");
     ASSERT_EQ(configuration.simple_configuration->app_metadata, "");
-    ASSERT_EQ(configuration.simple_configuration->is_repeater, false);
+    ASSERT_FALSE(configuration.simple_configuration->is_repeater);
 
     ASSERT_EQ(configuration.spy_configuration->id, "Fast-Spy-007");
     ASSERT_EQ(configuration.spy_configuration->app_id, "FASTDDS_SPY");
     ASSERT_EQ(configuration.spy_configuration->app_metadata, "");
-    ASSERT_EQ(configuration.spy_configuration->is_repeater, false);
+    ASSERT_FALSE(configuration.spy_configuration->is_repeater);
 }
 
 int main(


### PR DESCRIPTION
Store `app_id` and `app_metadata` attributes in  Fast DDS Spy participants.

Merge after:
- https://github.com/eProsima/DDS-Pipe/pull/72