### PR TITLE
Add internal builtin topics as DdsTopic(s)

### DIFF
--- a/fastddsspy_participants/test/blackbox/model/EndpointDatabaseTest.cpp
+++ b/fastddsspy_participants/test/blackbox/model/EndpointDatabaseTest.cpp
@@ -118,7 +118,7 @@ std::shared_ptr<DdsPipe> create_pipe(
 
     // Create a built-in topic to transmit endpoint information
     ddspipe_configuration.builtin_topics.insert(
-        utils::Heritable<types::DistributedTopic>::make_heritable(
+        utils::Heritable<types::DdsTopic>::make_heritable(
             spy::participants::endpoint_info_topic()));
 
     std::shared_ptr<DdsPipe> pipe =

--- a/fastddsspy_participants/test/blackbox/model/ParticipantDatabaseTest.cpp
+++ b/fastddsspy_participants/test/blackbox/model/ParticipantDatabaseTest.cpp
@@ -119,7 +119,7 @@ std::shared_ptr<DdsPipe> create_pipe(
 
     // Create a built-in topic to transmit participant information
     ddspipe_configuration.builtin_topics.insert(
-        utils::Heritable<types::DistributedTopic>::make_heritable(
+        utils::Heritable<types::DdsTopic>::make_heritable(
             spy::participants::participant_info_topic()));
 
     std::shared_ptr<DdsPipe> pipe =

--- a/fastddsspy_tool/src/cpp/tool/Backend.cpp
+++ b/fastddsspy_tool/src/cpp/tool/Backend.cpp
@@ -65,17 +65,17 @@ Backend::Backend(
 
     // Create a built-in topic to transmit participant information
     configuration_.ddspipe_configuration.builtin_topics.insert(
-        utils::Heritable<eprosima::ddspipe::core::types::DistributedTopic>::make_heritable(
+        utils::Heritable<eprosima::ddspipe::core::types::DdsTopic>::make_heritable(
             spy::participants::participant_info_topic()));
 
     // Create a built-in topic to transmit endpoint information
     configuration_.ddspipe_configuration.builtin_topics.insert(
-        utils::Heritable<eprosima::ddspipe::core::types::DistributedTopic>::make_heritable(
+        utils::Heritable<eprosima::ddspipe::core::types::DdsTopic>::make_heritable(
             spy::participants::endpoint_info_topic()));
 
     // Create an internal topic to transmit the dynamic types
     configuration_.ddspipe_configuration.builtin_topics.insert(
-        utils::Heritable<eprosima::ddspipe::core::types::DistributedTopic>::make_heritable(
+        utils::Heritable<eprosima::ddspipe::core::types::DdsTopic>::make_heritable(
             eprosima::ddspipe::core::types::type_object_topic()));
 
     if (!configuration_.ddspipe_configuration.allowlist.empty())


### PR DESCRIPTION
PR https://github.com/eProsima/Fast-DDS-spy/pull/56 introduced a regression in which internal builtin topics were added as `DistributedTopic` instead of `DdsTopic`. As a consequence, these were not well processed when an allowlist was being provided (casting to `DdsTopic` failed).