### PR TITLE
Process an empty YAML when a configuration file isn't provided

### DIFF
--- a/fastddsspy_tool/src/cpp/main.cpp
+++ b/fastddsspy_tool/src/cpp/main.cpp
@@ -131,15 +131,14 @@ int main(
         // Fast DDS Spy Initialization
 
         // Default configuration. Load it from file if file exists
-        eprosima::spy::yaml::Configuration configuration;
-
         if (file_path != "")
         {
             logInfo(
                 FASTDDSSPY_TOOL,
                 "Loading configuration from file '" << file_path << "' .");
-            configuration = eprosima::spy::yaml::Configuration(file_path);
         }
+
+        eprosima::spy::yaml::Configuration configuration = eprosima::spy::yaml::Configuration(file_path);
 
         // Create the Spy
         eprosima::spy::Controller spy(configuration);

--- a/fastddsspy_tool/test/application/test_cases/one_shot_topics_dds_no_config.py
+++ b/fastddsspy_tool/test/application/test_cases/one_shot_topics_dds_no_config.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/fastddsspy_tool/test/application/test_cases/one_shot_topics_dds_no_config.py
+++ b/fastddsspy_tool/test/application/test_cases/one_shot_topics_dds_no_config.py
@@ -1,0 +1,45 @@
+# Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the fastddsspy executable."""
+
+import test_class
+
+
+class TestCase_instance (test_class.TestCase):
+    """@brief A subclass of `test_class.TestCase` representing a specific test case."""
+
+    def __init__(self):
+        """
+        @brief Initialize the TestCase_instance object.
+
+        Launch this test with:
+            fastddsspy
+            AdvancedConfigurationExample publisher
+        """
+        super().__init__(
+            name='TopicsDDSNoConfigCommand',
+            one_shot=True,
+            command=[],
+            dds=True,
+            config='',
+            arguments_dds=[],
+            arguments_spy=['topics'],
+            commands_spy=[],
+            output="""- name: HelloWorldTopic\n\
+  type: HelloWorld\n\
+  datawriters: 1\n\
+  datareaders: 0\n\
+  rate: %%rate%%\n"""
+        )

--- a/fastddsspy_tool/test/application/test_cases/tool_topics_dds_no_config.py
+++ b/fastddsspy_tool/test/application/test_cases/tool_topics_dds_no_config.py
@@ -37,7 +37,7 @@ class TestCase_instance (test_class.TestCase):
             config='',
             arguments_dds=[],
             arguments_spy=[],
-            commands_spy=['topic HelloWorldTopic'],
+            commands_spy=['topics'],
             output=""">> \x1b[0m- name: HelloWorldTopic\n\
 \n\
   type: HelloWorld\n\

--- a/fastddsspy_tool/test/application/test_cases/tool_topics_dds_no_config.py
+++ b/fastddsspy_tool/test/application/test_cases/tool_topics_dds_no_config.py
@@ -1,0 +1,50 @@
+# Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the fastddsspy executable."""
+
+import test_class
+
+
+class TestCase_instance (test_class.TestCase):
+    """@brief A subclass of `test_class.TestCase` representing a specific test case."""
+
+    def __init__(self):
+        """
+        @brief Initialize the TestCase_instance object.
+
+        This test is launched with:
+            fastddsspy
+            >> topics
+            AdvancedConfigurationExample publisher
+        """
+        super().__init__(
+            name='ToolShowTopicDDSCommand',
+            one_shot=False,
+            command=[],
+            dds=True,
+            config='',
+            arguments_dds=[],
+            arguments_spy=[],
+            commands_spy=['topic HelloWorldTopic'],
+            output=""">> \x1b[0m- name: HelloWorldTopic\n\
+\n\
+  type: HelloWorld\n\
+\n\
+  datawriters: 1\n\
+\n\
+  datareaders: 0\n\
+\n\
+  rate: %%rate%%\n"""
+        )

--- a/fastddsspy_tool/test/application/test_cases/tool_topics_dds_no_config.py
+++ b/fastddsspy_tool/test/application/test_cases/tool_topics_dds_no_config.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/fastddsspy_tool/test/application/test_class.py
+++ b/fastddsspy_tool/test/application/test_class.py
@@ -167,12 +167,13 @@ class TestCase():
         @param rate: The rate to check.
         @return Returns True if the rate is valid, False otherwise.
         """
-        pattern_1 = r'^(\d*\.?\d*\s(Hz))$'     # rate: 10.5 Hz
-        pattern_2 = r'^((inf)\s(Hz))$'         # rate: inf Hz
-        if re.match(pattern_1, rate):
-            return True
-        if re.match(pattern_2, rate):
-            return True
+        pattern = r'^(\d+(\.\d+)?|inf)\sHz$'     # rate: (10.5 | inf) Hz
+
+        match = re.match(pattern, rate)
+
+        if match:
+            return match.group(1) == "inf" or float(match.group(1)) > 0
+
         print('Not valid rate: ')
         print(rate)
         return False

--- a/fastddsspy_tool/test/application/test_class.py
+++ b/fastddsspy_tool/test/application/test_class.py
@@ -172,7 +172,7 @@ class TestCase():
         match = re.match(pattern, rate)
 
         if match:
-            return match.group(1) == "inf" or float(match.group(1)) > 0
+            return match.group(1) == 'inf' or float(match.group(1)) > 0
 
         print('Not valid rate: ')
         print(rate)

--- a/fastddsspy_tool/test/labels/XTSAN.list
+++ b/fastddsspy_tool/test/labels/XTSAN.list
@@ -11,6 +11,7 @@ tool.application.fastddsspy.test.test_cases.one_shot_participants_guid_dds
 tool.application.fastddsspy.test.test_cases.one_shot_participants_verbose_dds
 tool.application.fastddsspy.test.test_cases.one_shot_quit_dds
 tool.application.fastddsspy.test.test_cases.one_shot_topics_dds
+tool.application.fastddsspy.test.test_cases.one_shot_topics_dds_no_config
 tool.application.fastddsspy.test.test_cases.one_shot_topics_name_dds
 tool.application.fastddsspy.test.test_cases.one_shot_topics_verbose_dds
 tool.application.fastddsspy.test.test_cases.tool_datareader_dds
@@ -19,6 +20,7 @@ tool.application.fastddsspy.test.test_cases.tool_help_dds
 tool.application.fastddsspy.test.test_cases.tool_participants_dds
 tool.application.fastddsspy.test.test_cases.tool_show_topic_dds
 tool.application.fastddsspy.test.test_cases.tool_topics_dds
+tool.application.fastddsspy.test.test_cases.tool_topics_dds_no_config
 tool.application.fastddsspy.test.test_cases.one_shot__config
 tool.application.fastddsspy.test.test_cases.one_shot__config_fail_file
 tool.application.fastddsspy.test.test_cases.one_shot__config_fail_type

--- a/fastddsspy_yaml/include/fastddsspy_yaml/YamlReaderConfiguration.hpp
+++ b/fastddsspy_yaml/include/fastddsspy_yaml/YamlReaderConfiguration.hpp
@@ -87,6 +87,9 @@ protected:
     void load_dds_configuration_(
             const Yaml& yml,
             const ddspipe::yaml::YamlReaderVersion& version);
+
+    void load_configuration_from_file_(
+            const std::string& file_path);
 };
 
 } /* namespace yaml */

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -61,9 +61,9 @@ Configuration::Configuration(
 
 Configuration::Configuration(
         const std::string& file_path)
-    : Configuration(YamlManager::load_file(file_path))
+    : Configuration()
 {
-    // Do nothing
+    load_configuration_from_file_(file_path);
 }
 
 void Configuration::load_configuration_(
@@ -105,7 +105,7 @@ void Configuration::load_configuration_(
         ddspipe_configuration.blocklist.insert(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_response_topic));
 
-        // Only trigger the DdsPipe's callbacks with the discovery (and removal) of writers.
+        // Only trigger the DdsPipe's callbacks when discovering or removing writers
         ddspipe_configuration.discovery_trigger = DiscoveryTrigger::WRITER;
     }
     catch (const std::exception& e)
@@ -213,6 +213,29 @@ void Configuration::load_specs_configuration_(
     {
         one_shot_wait_time_ms = YamlReader::get<utils::Duration_ms>(yml, GATHERING_TIME_TAG, version);
     }
+}
+
+void Configuration::load_configuration_from_file_(
+        const std::string& file_path)
+{
+    Yaml yml;
+
+    // Load file
+    try
+    {
+        if (!file_path.empty())
+        {
+            yml = YamlManager::load_file(file_path);
+        }
+    }
+    catch (const std::exception& e)
+    {
+        throw eprosima::utils::ConfigurationException(
+                  utils::Formatter() << "Error loading Fast-DDS Spy configuration from file: <" << file_path <<
+                      "> :\n " << e.what());
+    }
+
+    load_configuration_(yml);
 }
 
 bool Configuration::is_valid(


### PR DESCRIPTION
In the previous version, when a user didn't provide a configuration file, the Fast-DDS Spy didn't process the default YAML configuration. To fix it, in this version when a configuration file isn't provided, the Fast-DDS Spy processes an empty YAML into which it loads the default YAML configuration.