### PR TITLE
[20274] Validate the YAML configuration file on parsing

### DIFF
--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -23,6 +23,7 @@
 #include <ddspipe_yaml/Yaml.hpp>
 #include <ddspipe_yaml/YamlManager.hpp>
 #include <ddspipe_yaml/YamlReader.hpp>
+#include <ddspipe_yaml/YamlValidator.hpp>
 
 #include <fastddsspy_yaml/yaml_configuration_tags.hpp>
 
@@ -73,6 +74,12 @@ void Configuration::load_configuration_(
     {
         YamlReaderVersion version = LATEST;
 
+        const std::set<TagType> tags{
+            SPECS_TAG,
+            DDS_TAG};
+
+        YamlValidator::validate_tags(yml, tags);
+
         /////
         // Get optional specs configuration options
         if (YamlReader::is_tag_present(yml, SPECS_TAG))
@@ -119,6 +126,18 @@ void Configuration::load_dds_configuration_(
         const Yaml& yml,
         const ddspipe::yaml::YamlReaderVersion& version)
 {
+    const std::set<TagType> tags{
+        ALLOWLIST_TAG,
+        BLOCKLIST_TAG,
+        TOPICS_TAG,
+        DOMAIN_ID_TAG,
+        WHITELIST_INTERFACES_TAG,
+        TRANSPORT_DESCRIPTORS_TRANSPORT_TAG,
+        IGNORE_PARTICIPANT_FLAGS_TAG,
+        ROS2_TYPES_TAG};
+
+    YamlValidator::validate_tags(yml, tags);
+
     /////
     // Get optional allowlist
     if (YamlReader::is_tag_present(yml, ALLOWLIST_TAG))
@@ -194,6 +213,13 @@ void Configuration::load_specs_configuration_(
         const Yaml& yml,
         const ddspipe::yaml::YamlReaderVersion& version)
 {
+    const std::set<TagType> tags{
+        NUMBER_THREADS_TAG,
+        SPECS_QOS_TAG,
+        GATHERING_TIME_TAG};
+
+    YamlValidator::validate_tags(yml, tags);
+
     // Get optional number of threads
     if (YamlReader::is_tag_present(yml, NUMBER_THREADS_TAG))
     {
@@ -204,7 +230,7 @@ void Configuration::load_specs_configuration_(
     // Get optional Topic QoS
     if (YamlReader::is_tag_present(yml, SPECS_QOS_TAG))
     {
-        YamlReader::fill<TopicQoS>(topic_qos, YamlReader::get_value_in_tag(yml, SPECS_QOS_TAG), version);
+        topic_qos = YamlReader::get<TopicQoS>(yml, SPECS_QOS_TAG, version);
         TopicQoS::default_topic_qos.set_value(topic_qos);
     }
 

--- a/fastddsspy_yaml/src/cpp/YamlReader_configuration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReader_configuration.cpp
@@ -1,0 +1,52 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file YamlReader_configuration.cpp
+ *
+ * File to redefine the validate function for the types that are different in the Fast-DDS Spy.
+ */
+
+#include <ddspipe_core/types/dds/TopicQoS.hpp>
+
+#include <ddspipe_yaml/yaml_configuration_tags.hpp>
+#include <ddspipe_yaml/YamlValidator.hpp>
+
+namespace eprosima {
+namespace ddspipe {
+namespace yaml {
+
+template <>
+DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<core::types::TopicQoS>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    // The QOS_MAX_TX_RATE_TAG is not a valid TopicQoS
+    const std::set<TagType> tags{
+        QOS_TRANSIENT_TAG,
+        QOS_RELIABLE_TAG,
+        QOS_OWNERSHIP_TAG,
+        QOS_PARTITION_TAG,
+        QOS_HISTORY_DEPTH_TAG,
+        QOS_KEYED_TAG,
+        QOS_MAX_RX_RATE_TAG,
+        QOS_DOWNSAMPLING_TAG};
+
+    return YamlValidator::validate_tags(yml, tags);
+}
+
+} /* namespace yaml */
+} /* namespace ddspipe */
+} /* namespace eprosima */


### PR DESCRIPTION
In this version, the Fast-DDS Spy throws a warning when a YAML tag is ignored to prevent typos, misplacements, and wrong configurations.