### PR TITLE
[19983] Publish Fast-DDS's Logs

### DIFF
--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -336,10 +336,9 @@ By default, the filter allows all errors to be displayed, while selectively perm
     For the logs to function properly, the ``-DLOG_INFO=ON`` compilation flag is required.
 
 
-By default, the logs will be printed in the standard output.
+The |spy| prints the logs by default (warnings and errors in the standard error and infos in the standard output).
+The |spy|, however, can also publish the logs in a DDS topic.
 To publish the logs, under the tag ``publish``, set ``enable: true`` and set a ``domain`` and a ``topic-name``.
-The type of the logs can be published by setting ``publish-type: true``.
-
 The type of the logs published is defined as follows:
 
 **LogEntry.idl**
@@ -364,6 +363,10 @@ The type of the logs published is defined as follows:
       string message;
       string timestamp;
     };
+
+.. note::
+
+    The type of the logs can be published by setting ``publish-type: true``.
 
 **Example of usage**
 

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -299,15 +299,6 @@ When configuring the verbosity to ``info``, all types of logs, including informa
 Conversely, setting it to ``warning`` will only show warnings and errors, while choosing ``error`` will exclusively display errors.
 By default, the filter allows all errors to be displayed, while selectively permitting warning messages from ``DDSPIPE|FASTDDSSPY`` and informational messages from the ``FASTDDSSPY`` category.
 
-.. code-block:: yaml
-
-    logging:
-      verbosity: info
-      filter:
-        error: "DDSPIPE|FASTDDSSPY"
-        warning: "DDSPIPE|FASTDDSSPY"
-        info: "FASTDDSSPY"
-
 .. note::
 
     Configuring the logs via the Command-Line is still active and takes precedence over YAML configuration when both methods are used simultaneously.
@@ -344,6 +335,52 @@ By default, the filter allows all errors to be displayed, while selectively perm
 
     For the logs to function properly, the ``-DLOG_INFO=ON`` compilation flag is required.
 
+
+By default, the logs will be printed in the standard output.
+To publish the logs, under the tag ``publish``, set ``enable: true`` and set a ``domain`` and a ``topic-name``.
+The type of the logs can be published by setting ``publish-type: true``.
+
+The type of the logs published is defined as follows:
+
+**LogEntry.idl**
+
+.. code-block:: idl
+
+    const long UNDEFINED = 0x10000000;
+    const long SAMPLE_LOST = 0x10000001;
+    const long TOPIC_MISMATCH_TYPE = 0x10000002;
+    const long TOPIC_MISMATCH_QOS = 0x10000003;
+
+    enum Kind {
+      Info,
+      Warning,
+      Error
+    };
+
+    struct LogEntry {
+      @key long event;
+      Kind kind;
+      string category;
+      string message;
+      string timestamp;
+    };
+
+**Example of usage**
+
+.. code-block:: yaml
+
+    logging:
+      verbosity: info
+      filter:
+        error: "DDSPIPE|FASTDDSSPY"
+        warning: "DDSPIPE|FASTDDSSPY"
+        info: "FASTDDSSPY"
+      publish:
+        enable: true
+        domain: 84
+        topic-name: "FastDdsSpyLogs"
+        publish-type: false
+      stdout: true
 
 .. _user_manual_configuration_default:
 
@@ -398,3 +435,9 @@ This is a YAML file that uses all supported configurations and set them as defau
           error: "DDSPIPE|FASTDDSSPY"
           warning: "DDSPIPE|FASTDDSSPY"
           info: "FASTDDSSPY"
+        publish:
+          enable: true
+          domain: 84
+          topic-name: "FastDdsSpyLogs"
+          publish-type: false
+        stdout: true

--- a/fastddsspy_tool/src/cpp/main.cpp
+++ b/fastddsspy_tool/src/cpp/main.cpp
@@ -23,8 +23,7 @@
 #include <cpp_utils/event/SignalEventHandler.hpp>
 #include <cpp_utils/exception/ConfigurationException.hpp>
 #include <cpp_utils/exception/InitializationException.hpp>
-#include <cpp_utils/logging/CustomStdLogConsumer.hpp>
-#include <cpp_utils/logging/LogConfiguration.hpp>
+#include <cpp_utils/logging/StdLogConsumer.hpp>
 #include <cpp_utils/ReturnCode.hpp>
 #include <cpp_utils/thread_pool/pool/SlotThreadPool.hpp>
 #include <cpp_utils/time/time_utils.hpp>
@@ -35,6 +34,7 @@
 #include <ddspipe_core/dynamic/ParticipantsDatabase.hpp>
 #include <ddspipe_core/dynamic/DiscoveryDatabase.hpp>
 #include <ddspipe_core/efficiency/payload/FastPayloadPool.hpp>
+#include <ddspipe_core/logging/DdsLogConsumer.hpp>
 
 #include <ddspipe_participants/participant/dynamic_types/SchemaParticipant.hpp>
 #include <ddspipe_participants/participant/dynamic_types/DynTypesParticipant.hpp>
@@ -70,7 +70,6 @@ int main(
     {
         return static_cast<int>(arg_parse_result);
     }
-
 
     // Check file is in args, else get the default file
     if (commandline_args.file_path == "")
@@ -112,15 +111,27 @@ int main(
 
         // Debug
         {
+            const auto log_configuration = configuration.ddspipe_configuration.log_configuration;
+
             // Remove every consumer
             eprosima::utils::Log::ClearConsumers();
 
             // Activate log with verbosity, as this will avoid running log thread with not desired kind
             eprosima::utils::Log::SetVerbosity(configuration.ddspipe_configuration.log_configuration.verbosity);
 
-            eprosima::utils::LogConfiguration log_config = configuration.ddspipe_configuration.log_configuration;
-            eprosima::utils::Log::RegisterConsumer(
-                std::make_unique<eprosima::utils::CustomStdLogConsumer>(&log_config));
+            // Stdout Log Consumer
+            if (log_configuration.stdout_enable)
+            {
+                eprosima::utils::Log::RegisterConsumer(
+                    std::make_unique<eprosima::utils::StdLogConsumer>(&log_configuration));
+            }
+
+            // DDS Log Consumer
+            if (log_configuration.publish.enable)
+            {
+                eprosima::utils::Log::RegisterConsumer(
+                    std::make_unique<eprosima::ddspipe::core::DdsLogConsumer>(&log_configuration));
+            }
 
             // NOTE:
             // It will not filter any log, so Fast DDS logs will be visible unless Fast DDS is compiled

--- a/fastddsspy_tool/src/cpp/main.cpp
+++ b/fastddsspy_tool/src/cpp/main.cpp
@@ -249,5 +249,8 @@ int main(
     // Force print every log before closing
     eprosima::utils::Log::Flush();
 
+    // Delete the consumers before closing
+    eprosima::utils::Log::ClearConsumers();
+
     return static_cast<int>(eprosima::spy::ProcessReturnCode::success);
 }

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -235,7 +235,8 @@ void Configuration::load_specs_configuration_(
     // Get optional Log Configuration
     if (YamlReader::is_tag_present(yml, LOG_CONFIGURATION_TAG))
     {
-        ddspipe_configuration.log_configuration = YamlReader::get<DdsPipeLogConfiguration>(yml, LOG_CONFIGURATION_TAG, version);
+        ddspipe_configuration.log_configuration = YamlReader::get<DdsPipeLogConfiguration>(yml, LOG_CONFIGURATION_TAG,
+                        version);
     }
 }
 

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
 #include <ddspipe_core/types/dds/TopicQoS.hpp>
 #include <ddspipe_core/types/dynamic_types/types.hpp>
 #include <ddspipe_core/types/topic/dds/DdsTopic.hpp>
@@ -234,8 +235,7 @@ void Configuration::load_specs_configuration_(
     // Get optional Log Configuration
     if (YamlReader::is_tag_present(yml, LOG_CONFIGURATION_TAG))
     {
-        ddspipe_configuration.log_configuration = YamlReader::get<utils::LogConfiguration>(yml, LOG_CONFIGURATION_TAG,
-                        version);
+        ddspipe_configuration.log_configuration = YamlReader::get<DdsPipeLogConfiguration>(yml, LOG_CONFIGURATION_TAG, version);
     }
 }
 


### PR DESCRIPTION
In this version, users can configure through the YAML the publication of Fast DDS's logs. 

Merge after:
- https://github.com/eProsima/dev-utils/pull/92
- https://github.com/eProsima/DDS-Pipe/pull/86
- https://github.com/eProsima/Fast-DDS-spy/pull/74
- https://github.com/eProsima/dev-utils/pull/97
- https://github.com/eProsima/DDS-Pipe/pull/92