### PR TITLE
Change default log filter configuration

### DIFF
--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -297,7 +297,7 @@ Logging
 Under the ``logging`` tag, users can configure the type of logs to display and filter the logs based on their content and category.
 When configuring the verbosity to ``info``, all types of logs, including informational messages, warnings, and errors, will be displayed.
 Conversely, setting it to ``warning`` will only show warnings and errors, while choosing ``error`` will exclusively display errors.
-By default, the filter allows all errors to be displayed, while selectively permitting warning messages from ``DDSPIPE|FASTDDSSPY`` and informational messages from the ``FASTDDSSPY`` category.
+By default, the filter allows all errors to be displayed, while selectively permitting warning messages from ``FASTDDSSPY`` and informational messages from the ``FASTDDSSPY`` category.
 
 .. note::
 
@@ -327,7 +327,7 @@ By default, the filter allows all errors to be displayed, while selectively perm
           or message of the logs.
         - *string*
         - info : ``FASTDDSSPY`` |br|
-          warning : ``DDSPIPE|FASTDDSSPY`` |br|
+          warning : ``FASTDDSSPY`` |br|
           error : ``""``
         - Regex string
 

--- a/fastddsspy_tool/src/cpp/user_interface/arguments_configuration.cpp
+++ b/fastddsspy_tool/src/cpp/user_interface/arguments_configuration.cpp
@@ -232,7 +232,7 @@ ProcessReturnCode parse_arguments(
 
             case optionIndex::ACTIVATE_DEBUG:
                 commandline_args.log_filter[utils::VerbosityKind::Error].set_value("");
-                commandline_args.log_filter[utils::VerbosityKind::Warning].set_value("(FASTDDSSPY|DDSPIPE)");
+                commandline_args.log_filter[utils::VerbosityKind::Warning].set_value("FASTDDSSPY");
                 commandline_args.log_filter[utils::VerbosityKind::Info].set_value("FASTDDSSPY");
                 commandline_args.log_verbosity = utils::VerbosityKind::Info;
                 break;

--- a/fastddsspy_yaml/src/cpp/CommandlineArgsSpy.cpp
+++ b/fastddsspy_yaml/src/cpp/CommandlineArgsSpy.cpp
@@ -21,7 +21,7 @@ namespace yaml {
 CommandlineArgsSpy::CommandlineArgsSpy()
 {
     log_filter[utils::VerbosityKind::Info].set_value("FASTDDSSPY", utils::FuzzyLevelValues::fuzzy_level_default);
-    log_filter[utils::VerbosityKind::Warning].set_value("FASTDDSSPY|DDSPIPE",
+    log_filter[utils::VerbosityKind::Warning].set_value("FASTDDSSPY",
             utils::FuzzyLevelValues::fuzzy_level_default);
     log_filter[utils::VerbosityKind::Error].set_value("", utils::FuzzyLevelValues::fuzzy_level_default);
 }


### PR DESCRIPTION
Change default log filter configuration in FastDDSSpy tool to:
          - info : ``FASTDDSSPY``
          - warning : ``FASTDDSSPY``
          - error : ``""``