### PR TITLE
Fixed option to install using tar

### DIFF
--- a/docs/rst/installation/docker.rst
+++ b/docs/rst/installation/docker.rst
@@ -22,7 +22,7 @@ The steps to run |spy| in a Docker container are explained below.
 
     .. code-block:: bash
 
-        docker load ubuntu-fastddsspy:<version>.tar
+        docker load -i ubuntu-fastddsspy:<version>.tar
 
     where ``version`` is the downloaded version of |spy|.
 


### PR DESCRIPTION
Fixed option to install using tar. without `-i` docker returns error

```bash
docker load --help

Usage:  docker load [OPTIONS]

Load an image from a tar archive or STDIN

Aliases:
  docker image load, docker load

Options:
  -i, --input string   Read from tar archive file, instead of STDIN
  -q, --quiet          Suppress the load output
```

docker version 24

```bash
docker --version
Docker version 24.0.7, build 24.0.7-0ubuntu2~22.04.1
```