### PR TITLE
 [22870] Support ROS 2 Easy Mode

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -244,7 +244,7 @@ release = u'{}.{}.{}'.format(
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -6,3 +6,9 @@
 ###################
 Forthcoming Version
 ###################
+
+This release include the following **major changes**:
+
+* Add support to configure ROS 2 Easy Mode in the *yaml* configuration file.
+
+  - New ``ros2-easy-mode`` tag added.

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -7,8 +7,8 @@
 Forthcoming Version
 ###################
 
-This release include the following **major changes**:
+Next release will include the following **major changes**:
 
 * Add support to configure ROS 2 Easy Mode in the *yaml* configuration file.
 
-  - New ``ros2-easy-mode`` tag added.
+  - New ``ros2-easy-mode`` tag added. Check :ref:`user_manual_configuration_dds__ros2_easy_mode` section.

--- a/docs/rst/notes/notes.rst
+++ b/docs/rst/notes/notes.rst
@@ -2,7 +2,7 @@
 
 .. _notes:
 
-.. .. include:: forthcoming_version.rst
+.. include:: forthcoming_version.rst
 
 ##############
 Version v1.1.0

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -241,7 +241,7 @@ through the ``ros2-easy-mode`` tag.
 
 .. warning::
     This configuration is incompatible with the ``transports`` tag.
-    Setting ``ros2-easy-mode`` along with ``transports: udp`` or ``transports: shm``
+    Setting ``ros2-easy-mode`` other than ``transports: builtin``
     will prevent Easy Mode from being configured.
 
     For now, only IPv4 addresses are supported.

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -226,6 +226,25 @@ However, a user may desire to force the use of one of the two, which can be acco
 
     When configured with ``transport: shm``, |spy| will only communicate with applications using Shared Memory Transport exclusively (with disabled UDP transport).
 
+.. _user_manual_configuration_dds__ros2_easy_mode:
+
+ROS 2 Easy Mode Configuration
+-----------------------------
+
+Fast DDS Spy allows configuring the address of a remote discovery server when using
+`ROS 2 Easy Mode <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__
+through the ``ros2-easy-mode`` tag.
+
+.. code-block:: yaml
+
+    ros2-easy-mode: "2.2.2.2"       # Remote discovery server address
+
+.. warning::
+    This configuration is incompatible with the ``transports`` tag.
+    Setting ``ros2-easy-mode`` along with ``transports: udp`` or ``transports: shm``
+    will prevent Easy Mode from being configured.
+
+    For now, only IPv4 addresses are supported.
 
 .. _user_manual_configuration_dds__interface_whitelist:
 
@@ -413,6 +432,7 @@ A complete example of all the configurations described on this page can be found
 
       ignore-participant-flags: no_filter
       transport: builtin
+      ros2-easy-mode: "2.2.2.2"
       whitelist-interfaces:
         - "127.0.0.1"
 

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -231,7 +231,7 @@ However, a user may desire to force the use of one of the two, which can be acco
 ROS 2 Easy Mode Configuration
 -----------------------------
 
-Fast DDS Spy allows configuring the address of a remote discovery server when using
+|spy| allows configuring the address of a remote discovery server when using
 `ROS 2 Easy Mode <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__
 through the ``ros2-easy-mode`` tag.
 

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -193,6 +193,11 @@ void Configuration::load_dds_configuration_(
         simple_configuration->transport = TransportDescriptors::builtin;
     }
 
+    if (YamlReader::is_tag_present(yml, EASY_MODE_TAG))
+    {
+        simple_configuration->easy_mode_ip = YamlReader::get<IpType>(yml, EASY_MODE_TAG, version);
+    }
+
     // Optional get ignore participant flags
     if (YamlReader::is_tag_present(yml, IGNORE_PARTICIPANT_FLAGS_TAG))
     {

--- a/fastddsspy_yaml/test/unittest/yaml_reader/YamlReaderTest.cpp
+++ b/fastddsspy_yaml/test/unittest/yaml_reader/YamlReaderTest.cpp
@@ -31,6 +31,7 @@ TEST(YamlReaderTest, get_spy_configuration_trivial)
             version: v4.0
             dds:
                 ros2-types: true
+                ros2-easy-mode: '127.0.0.1'
         )";
 
     Yaml yml = YAML::Load(yml_str);
@@ -55,6 +56,8 @@ TEST(YamlReaderTest, get_spy_configuration_trivial)
     ASSERT_EQ(configuration.spy_configuration->app_id, "FASTDDS_SPY");
     ASSERT_EQ(configuration.spy_configuration->app_metadata, "");
     ASSERT_FALSE(configuration.spy_configuration->is_repeater);
+
+    ASSERT_EQ(configuration.simple_configuration->easy_mode_ip, "127.0.0.1");
 }
 
 int main(


### PR DESCRIPTION
# Main Changes

This PR adds documentation for the new `ros2-easy-mode` tag, which allows configuring the IP of the remote Discovery Server when using Easy Mode. A unit test was added to verify the correct parsing of the attribute.

This PR must be merged after:
- https://github.com/eProsima/DDS-Pipe/pull/139