### PR TITLE
[#21850] Added idl support in DDS

### DIFF
--- a/fastddsspy_participants/include/fastddsspy_participants/participant/SpyDdsXmlParticipant.hpp
+++ b/fastddsspy_participants/include/fastddsspy_participants/participant/SpyDdsXmlParticipant.hpp
@@ -175,9 +175,11 @@ public:
          * Creates data containing the discovered endpoint and inserts it into the internal reader queue.
          *
          * @param endpoint_discovered The discovered endpoint information.
+         * @param type_idl The discovered endpoint type in IDL format.
          */
         void internal_notify_endpoint_discovered_(
-                const EndpointInfo& endpoint_discovered);
+                const EndpointInfo& endpoint_discovered,
+                const std::string& type_idl);
 
         /// Participants Internal Reader
         std::shared_ptr<ddspipe::participants::InternalReader> participants_reader_;

--- a/fastddsspy_participants/include/fastddsspy_participants/participant/detail/TypeIdlProvider.hpp
+++ b/fastddsspy_participants/include/fastddsspy_participants/participant/detail/TypeIdlProvider.hpp
@@ -31,7 +31,7 @@ namespace spy {
 namespace participants {
 namespace detail {
 
-template <typename EndpointDiscoveryInfo>
+template<typename EndpointDiscoveryInfo>
 static std::string get_type_idl(
         const EndpointDiscoveryInfo& info)
 {

--- a/fastddsspy_participants/include/fastddsspy_participants/participant/detail/TypeIdlProvider.hpp
+++ b/fastddsspy_participants/include/fastddsspy_participants/participant/detail/TypeIdlProvider.hpp
@@ -1,0 +1,73 @@
+// Copyright 2026 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <sstream>
+#include <string>
+
+#include <cpp_utils/Log.hpp>
+
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/xtypes/dynamic_types/DynamicTypeBuilder.hpp>
+#include <fastdds/dds/xtypes/dynamic_types/DynamicTypeBuilderFactory.hpp>
+#include <fastdds/dds/xtypes/utils.hpp>
+
+#include <fastddsspy_participants/library/config.h>
+
+namespace eprosima {
+namespace spy {
+namespace participants {
+namespace detail {
+
+template <typename EndpointDiscoveryInfo>
+static std::string get_type_idl(
+        const EndpointDiscoveryInfo& info)
+{
+    std::string type_idl {};
+
+    if (!info.type_information.assigned())
+    {
+        return type_idl;
+    }
+
+    fastdds::dds::xtypes::TypeObject remote_type_object;
+    if (eprosima::fastdds::dds::RETCODE_OK !=
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_object
+            (
+                info.type_information.type_information.complete().typeid_with_size().type_id(),
+                remote_type_object))
+    {
+        EPROSIMA_LOG_WARNING(FASTDDSSPY_DDS_PARTICIPANT,
+                "Error getting type object for type " << info.type_name);
+        return type_idl;
+    }
+
+    // Build remotely discovered type
+    fastdds::dds::DynamicType::_ref_type remote_type =
+            eprosima::fastdds::dds::DynamicTypeBuilderFactory::get_instance()->create_type_w_type_object(
+        remote_type_object)->build();
+
+    // Serialize DynamicType into its IDL representation
+    std::stringstream idl;
+    idl_serialize(remote_type, idl);
+    type_idl = idl.str();
+
+    return type_idl;
+}
+
+} /* namespace detail */
+} /* namespace participants */
+} /* namespace spy */
+} /* namespace eprosima */

--- a/fastddsspy_participants/src/cpp/participant/SpyDdsParticipant.cpp
+++ b/fastddsspy_participants/src/cpp/participant/SpyDdsParticipant.cpp
@@ -15,15 +15,10 @@
 #include <ddspipe_participants/utils/utils.hpp>
 
 #include <fastddsspy_participants/participant/SpyDdsParticipant.hpp>
+#include <fastddsspy_participants/participant/detail/TypeIdlProvider.hpp>
 #include <fastddsspy_participants/types/ParticipantInfo.hpp>
 #include <fastddsspy_participants/types/EndpointInfo.hpp>
 
-#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
-#include <fastdds/dds/xtypes/dynamic_types/DynamicTypeBuilderFactory.hpp>
-#include <fastdds/dds/xtypes/dynamic_types/DynamicTypeBuilder.hpp>
-
-#include <ddspipe_core/types/dynamic_types/types.hpp>
-#include <fastdds/dds/xtypes/utils.hpp>
 namespace eprosima {
 namespace spy {
 namespace participants {
@@ -116,34 +111,7 @@ void SpyDdsParticipant::SpyDdsParticipantListener::on_reader_discovery(
     ddspipe::participants::DynTypesParticipant::DynTypesRtpsListener::on_reader_discovery(participant, reason, info,
             should_be_ignored);
 
-    std::string type_idl {};
-
-    if (info.type_information.assigned())
-    {
-        fastdds::dds::xtypes::TypeObject remote_type_object;
-        if (eprosima::fastdds::dds::RETCODE_OK !=
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_object
-                (
-                    info.type_information.type_information.complete().typeid_with_size().type_id(),
-                    remote_type_object))
-        {
-            EPROSIMA_LOG_WARNING(FASTDDSSPY_DDS_PARTICIPANT,
-                    "Error getting type object for type " << info.type_name);
-        }
-        else
-        {
-            // Build remotely discovered type
-            fastdds::dds::DynamicType::_ref_type remote_type =
-                    eprosima::fastdds::dds::DynamicTypeBuilderFactory::get_instance()->create_type_w_type_object(
-                remote_type_object)->build();
-
-            // Serialize DynamicType into its IDL representation
-            std::stringstream idl;
-            idl_serialize(remote_type, idl);
-            type_idl = idl.str();
-        }
-    }
-
+    const std::string type_idl = detail::get_type_idl(info);
     internal_notify_endpoint_discovered_(endpoint_info, type_idl);
 }
 
@@ -166,31 +134,7 @@ void SpyDdsParticipant::SpyDdsParticipantListener::on_writer_discovery(
     ddspipe::participants::DynTypesParticipant::DynTypesRtpsListener::on_writer_discovery(participant, reason, info,
             should_be_ignored);
 
-    std::string type_idl {};
-
-    if (info.type_information.assigned())
-    {
-        fastdds::dds::xtypes::TypeObject remote_type_object;
-        if (eprosima::fastdds::dds::RETCODE_OK !=
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_object
-                (
-                    info.type_information.type_information.complete().typeid_with_size().type_id(),
-                    remote_type_object))
-        {
-            EPROSIMA_LOG_WARNING(FASTDDSSPY_DDS_PARTICIPANT,
-                    "Error getting type object for type " << info.type_name);
-        }
-
-        // Build remotely discovered type
-        fastdds::dds::DynamicType::_ref_type remote_type =
-                eprosima::fastdds::dds::DynamicTypeBuilderFactory::get_instance()->create_type_w_type_object(
-            remote_type_object)->build();
-
-        // Serialize DynamicType into its IDL representation
-        std::stringstream idl;
-        idl_serialize(remote_type, idl);
-        type_idl = idl.str();
-    }
+    const std::string type_idl = detail::get_type_idl(info);
     internal_notify_endpoint_discovered_(endpoint_info, type_idl);
 }
 

--- a/fastddsspy_participants/src/cpp/participant/SpyDdsXmlParticipant.cpp
+++ b/fastddsspy_participants/src/cpp/participant/SpyDdsXmlParticipant.cpp
@@ -20,6 +20,7 @@
 #include <ddspipe_participants/utils/utils.hpp>
 
 #include <fastddsspy_participants/participant/SpyDdsXmlParticipant.hpp>
+#include <fastddsspy_participants/participant/detail/TypeIdlProvider.hpp>
 #include <fastddsspy_participants/types/ParticipantInfo.hpp>
 #include <fastddsspy_participants/types/EndpointInfo.hpp>
 
@@ -115,7 +116,8 @@ void SpyDdsXmlParticipant::SpyDdsXmlParticipantListener::on_data_reader_discover
     ddspipe::participants::XmlDynTypesParticipant::XmlDynTypesDdsListener::on_data_reader_discovery(
         participant, reason, info, should_be_ignored);
 
-    internal_notify_endpoint_discovered_(endpoint_info);
+    const std::string type_idl = detail::get_type_idl(info);
+    internal_notify_endpoint_discovered_(endpoint_info, type_idl);
 }
 
 void SpyDdsXmlParticipant::SpyDdsXmlParticipantListener::on_data_writer_discovery(
@@ -137,7 +139,8 @@ void SpyDdsXmlParticipant::SpyDdsXmlParticipantListener::on_data_writer_discover
     ddspipe::participants::XmlDynTypesParticipant::XmlDynTypesDdsListener::on_data_writer_discovery(
         participant, reason, info, should_be_ignored);
 
-    internal_notify_endpoint_discovered_(endpoint_info);
+    const std::string type_idl = detail::get_type_idl(info);
+    internal_notify_endpoint_discovered_(endpoint_info, type_idl);
 }
 
 void SpyDdsXmlParticipant::SpyDdsXmlParticipantListener::internal_notify_participant_discovered_(
@@ -152,11 +155,13 @@ void SpyDdsXmlParticipant::SpyDdsXmlParticipantListener::internal_notify_partici
 }
 
 void SpyDdsXmlParticipant::SpyDdsXmlParticipantListener::internal_notify_endpoint_discovered_(
-        const EndpointInfo& endpoint_discovered)
+        const EndpointInfo& endpoint_discovered,
+        const std::string& type_idl)
 {
     // Create data containing Dynamic Type
     auto data = std::make_unique<EndpointInfoData>();
     data->info = endpoint_discovered;
+    data->type_idl = type_idl;
 
     // Insert new data in internal reader queue
     endpoints_reader_->simulate_data_reception(std::move(data));

--- a/fastddsspy_tool/test/application/test_cases/one_shot_topics_name_idl_dds_no_config.py
+++ b/fastddsspy_tool/test/application/test_cases/one_shot_topics_name_idl_dds_no_config.py
@@ -37,5 +37,6 @@ class TestCase_instance (test_class.TestCase):
             arguments_dds=[],
             arguments_spy=['topics', 'HelloWorldTopic', 'idl'],
             commands_spy=[],
-            output="""\nNo type information available and thus cannot print data.\n"""
+            output="""\n@extensibility(APPENDABLE)\nstruct \
+HelloWorld\n{\n    unsigned long index;\n    char message[20];\n};\n"""
         )


### PR DESCRIPTION
## Description

**Fast-DDS-Spy** now use DDS by default (instead of RTPS) and this command did not worked. In the `datareader/datawriter` discovery, the type_idl information is added to the endpoint database.

Also, a refactor is being added by creating a new file called `TypeIdlProvider.hpp` in the participant folder.

## Related PR https://github.com/eProsima/Fast-DDS-spy/pull/129