### PR TITLE
[#24280] Replace invalid `domain-id` core-dump with clean validation errors

### DIFF
--- a/docs/rst/user_manual/tool.rst
+++ b/docs/rst/user_manual/tool.rst
@@ -115,7 +115,7 @@ It shows the usage information of the application.
     Application parameters
     -c --config-path    Path to the Configuration File (yaml format) [Default: ./FASTDDSSPY_CONFIGURATION.yaml].
     -r --reload-time    Time period in seconds to reload configuration file. This is needed when FileWatcher functionality is not available (e.g. config file is a symbolic link). Value 0 does not reload file. [Default: 0].
-       --domain         Set the domain (0-255) to spy on. [Default = 0].
+       --domain         Set the domain (0-232) to spy on. [Default = 0].
 
     Debug parameters
     -d --debug          Set log verbosity to Info (Using this option with --log-filter and/or --log-verbosity will head to undefined behaviour).

--- a/fastddsspy_tool/src/cpp/user_interface/arguments_configuration.cpp
+++ b/fastddsspy_tool/src/cpp/user_interface/arguments_configuration.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <iostream>
+#include <exception>
 #include <string>
 #include <vector>
 
@@ -107,7 +108,7 @@ const option::Descriptor usage[] = {
         "domain",
         Arg::Numeric,
         "  \t--domain\t  \t" \
-        "Set the domain (0-255) to spy on. " \
+        "Set the domain (0-232) to spy on. " \
         "[Default = 0]."
     },
 
@@ -260,8 +261,34 @@ ProcessReturnCode parse_arguments(
                 break;
 
             case optionIndex::DOMAIN:
-                commandline_args.domain.set_value(std::stoi(opt.arg));
-                break;
+            {
+                const auto max_domain_id = static_cast<long>(ddspipe::core::types::DomainId::MAX_DOMAIN_ID);
+                long domain_value = 0;
+
+                try
+                {
+                    domain_value = std::stol(opt.arg);
+                }
+                catch (const std::exception&)
+                {
+                    EPROSIMA_LOG_ERROR(
+                        FASTDDSSPY_ARGS,
+                        "Domain ID must be between 0 and " << max_domain_id << ".");
+                    return ProcessReturnCode::incorrect_argument;
+                }
+
+                if (domain_value < 0 || domain_value > max_domain_id)
+                {
+                    EPROSIMA_LOG_ERROR(
+                        FASTDDSSPY_ARGS,
+                        "Domain ID must be between 0 and " << max_domain_id << ".");
+                    return ProcessReturnCode::incorrect_argument;
+                }
+
+                commandline_args.domain.set_value(
+                    static_cast<ddspipe::core::types::DomainIdType>(domain_value));
+            }
+            break;
 
             case optionIndex::UNKNOWN_OPT:
                 EPROSIMA_LOG_ERROR(FASTDDSSPY_ARGS, opt << " is not a valid argument.");

--- a/fastddsspy_tool/test/application/test_cases/one_shot__domain_fail.py
+++ b/fastddsspy_tool/test/application/test_cases/one_shot__domain_fail.py
@@ -53,7 +53,7 @@ Application parameters\n\
   -r --reload-time    Time period in seconds to reload configuration file. \
 This is needed when FileWatcher functionality is not available \
 (e.g. config file is a symbolic link). Value 0 does not reload file. [Default: 0].\n\
-     --domain         Set the domain (0-255) to spy on. [Default = 0].\n\
+     --domain         Set the domain (0-232) to spy on. [Default = 0].\n\
 \n\
 Debug parameters\n\
   -d --debug          Set log verbosity to Info                                   \

--- a/fastddsspy_tool/test/application/test_cases/one_shot__help.py
+++ b/fastddsspy_tool/test/application/test_cases/one_shot__help.py
@@ -61,7 +61,7 @@ Application parameters\n\
   -r --reload-time    Time period in seconds to reload configuration file. \
 This is needed when FileWatcher functionality is not available \
 (e.g. config file is a symbolic link). Value 0 does not reload file. [Default: 0].\n\
-     --domain         Set the domain (0-255) to spy on. [Default = 0].\n\
+     --domain         Set the domain (0-232) to spy on. [Default = 0].\n\
 \n\
 Debug parameters\n\
   -d --debug          Set log verbosity to Info                                   \

--- a/fastddsspy_yaml/src/cpp/CommandlineArgsSpy.cpp
+++ b/fastddsspy_yaml/src/cpp/CommandlineArgsSpy.cpp
@@ -29,9 +29,9 @@ CommandlineArgsSpy::CommandlineArgsSpy()
 bool CommandlineArgsSpy::is_valid(
         utils::Formatter& error_msg) const noexcept
 {
-    if (domain.get_value() < 0 || domain.get_value() > 255)
+    if (domain.get_value() < 0 || domain.get_value() > 232)
     {
-        error_msg << "Domain ID must be between 0 and 255";
+        error_msg << "Domain ID must be between 0 and 232";
         return false;
     }
 

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -328,6 +328,18 @@ void Configuration::load_configuration_from_file_(
 bool Configuration::is_valid(
         utils::Formatter& error_msg) const noexcept
 {
+    if (!dds_configuration)
+    {
+        error_msg << "DDS participant configuration is not initialized. ";
+        return false;
+    }
+
+    if (dds_configuration->domain.domain_id > DomainId::MAX_DOMAIN_ID)
+    {
+        error_msg << "Domain ID must be between 0 and " << DomainId::MAX_DOMAIN_ID << ".";
+        return false;
+    }
+
     if (n_threads < 1)
     {
         error_msg << "Must be at least 1 thread. ";


### PR DESCRIPTION
## Description

This PR fixes **invalid domain-id handling** so tools **fail fast with a clear user error instead of crashing.** 

Domain values are now validated consistently as [0, 232] for both CLI arguments and YAML configuration (including negative values). 

When invalid, applications exit cleanly and report: 
`2026-03-25 12:14:20.464 [FASTDDSSPY_ARGS Error] Domain ID must be between 0 and 232. -> Function parse_arguments`