### PR TITLE
[#24316] Reduced InstanceCache key warning spam

### DIFF
--- a/docs/rst/developer_manual/installation/sources/windows.rst
+++ b/docs/rst/developer_manual/installation/sources/windows.rst
@@ -201,7 +201,7 @@ Colcon installation (recommended)
         cd <path\to\user\workspace>\Fast-DDS-Spy
         mkdir src
         wget https://raw.githubusercontent.com/eProsima/Fast-DDS-Spy/main/fastddsspy.repos
-        vcs import src < fastddsspy.repos
+        vcs import src --input fastddsspy.repos
 
     .. note::
 

--- a/docs/rst/developer_manual/installation/sources/windows_cmake.rst
+++ b/docs/rst/developer_manual/installation/sources/windows_cmake.rst
@@ -24,7 +24,7 @@ Local installation
         mkdir <path\to\user\workspace>\fastdds-spy\build
         cd <path\to\user\workspace>\fastdds-spy
         wget https://raw.githubusercontent.com/eProsima/Fast-DDS-Spy/main/fastddsspy.repos
-        vcs import src < fastddsspy.repos
+        vcs import src --input fastddsspy.repos
 
 #.  Compile all dependencies using CMake_.
 

--- a/fastddsspy_participants/include/fastddsspy_participants/model/InstanceCache.hpp
+++ b/fastddsspy_participants/include/fastddsspy_participants/model/InstanceCache.hpp
@@ -147,6 +147,9 @@ private:
 
     // topic_name -> [key_field_names]
     std::map<std::string, std::vector<std::string>> key_fields_cache_;
+
+    // Topics already warned because key metadata could not be discovered
+    std::set<std::string> no_key_metadata_warned_topics_;
 };
 
 } /* namespace participants */

--- a/fastddsspy_participants/src/cpp/model/InstanceCache.cpp
+++ b/fastddsspy_participants/src/cpp/model/InstanceCache.cpp
@@ -47,6 +47,18 @@ bool InstanceCache::add_or_update_instance(
 
         extract_key_field_names_(topic.m_topic_name, dyn_type);
 
+        auto key_fields_it = key_fields_cache_.find(topic.m_topic_name);
+        if (key_fields_it == key_fields_cache_.end() || key_fields_it->second.empty())
+        {
+            if (no_key_metadata_warned_topics_.insert(topic.m_topic_name).second)
+            {
+                EPROSIMA_LOG_WARNING(FASTDDSSPY_INSTANCECACHE,
+                        "No key metadata discovered for topic: " << topic.m_topic_name
+                                                                 << ". Skipping key instance caching.");
+            }
+            return false;
+        }
+
         auto& topic_instances = instances_by_topic_[topic.m_topic_name];
 
         auto instance_it = topic_instances.find(instance_handle);
@@ -184,6 +196,7 @@ void InstanceCache::clear() noexcept
     std::unique_lock<std::shared_timed_mutex> lock(mutex_);
     instances_by_topic_.clear();
     key_fields_cache_.clear();
+    no_key_metadata_warned_topics_.clear();
 }
 
 // Private methods
@@ -192,8 +205,9 @@ void InstanceCache::extract_key_field_names_(
         const std::string& topic_name,
         const fastdds::dds::DynamicType::_ref_type& dyn_type) noexcept
 {
-    // Already cached?
-    if (key_fields_cache_.find(topic_name) != key_fields_cache_.end())
+    // Recompute only if key metadata has not been discovered yet
+    auto cached_keys_it = key_fields_cache_.find(topic_name);
+    if (cached_keys_it != key_fields_cache_.end() && !cached_keys_it->second.empty())
     {
         return;
     }


### PR DESCRIPTION
## Description

This PR fixes repeated `FASTDDSSPY_INSTANCECACHE` warnings caused by missing key metadata on incoming DynamicTypes, while preserving current key-caching behavior.

## Changes

- Added early short-circuit in `InstanceCache::add_or_update_instance`:
  - If no key fields are discovered for a topic, skip key serialization.
- Added one-time warning tracking set in `InstanceCache`.
- Improved key field cache behavior:
  - Do not permanently lock an empty key-field cache.
  - Recompute key fields when cached list is empty, allowing recovery if keyed schema arrives later.

## Related PR [Display the list of keys in a topic](https://github.com/eProsima/Fast-DDS-spy/pull/138)
