### PR TITLE
[#24321] Update foonathan version to 1.4.1 (.repos)

### DIFF
--- a/fastddsspy.repos
+++ b/fastddsspy.repos
@@ -2,7 +2,7 @@ repositories:
     foonathan_memory_vendor:
         type: git
         url: https://github.com/eProsima/foonathan_memory_vendor.git
-        version: v1.3.1
+        version: v1.4.1
     fastcdr:
         type: git
         url: https://github.com/eProsima/Fast-CDR.git


### PR DESCRIPTION
Fast `DDS v3.6.0` relies on `Foonathan v1.4.1`