### PR TITLE
[#24574] Fix macOS build issues in YAML parsing and CLI arguments

### DIFF
--- a/fastddsspy_tool/src/cpp/user_interface/arguments_configuration.cpp
+++ b/fastddsspy_tool/src/cpp/user_interface/arguments_configuration.cpp
@@ -102,7 +102,7 @@ const option::Descriptor usage[] = {
     },
 
     {
-        optionIndex::DOMAIN,
+        optionIndex::DOMAIN_ID,
         0,
         "",
         "domain",
@@ -260,7 +260,7 @@ ProcessReturnCode parse_arguments(
                         utils::VerbosityKind(static_cast<int>(from_string_LogKind(opt.arg)));
                 break;
 
-            case optionIndex::DOMAIN:
+            case optionIndex::DOMAIN_ID:
             {
                 const auto max_domain_id = static_cast<long>(ddspipe::core::types::DomainId::MAX_DOMAIN_ID);
                 long domain_value = 0;

--- a/fastddsspy_tool/src/cpp/user_interface/arguments_configuration.hpp
+++ b/fastddsspy_tool/src/cpp/user_interface/arguments_configuration.hpp
@@ -99,7 +99,7 @@ enum optionIndex
     VERSION,
     LOG_FILTER,
     LOG_VERBOSITY,
-    DOMAIN,
+    DOMAIN_ID,
 };
 
 /**

--- a/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
+++ b/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp
@@ -186,11 +186,9 @@ void Configuration::load_dds_configuration_(
 
         for (const auto& topic: manual_topics)
         {
-            const std::string key(topic.first->topic_name);
+            const std::string key(topic.first->topic_name.get_reference());
 
-            // force an unambiguous std::string
-            const std::string filter =
-                    static_cast<std::string>(topic.first->content_topic_filter);
+            const std::string filter = topic.first->content_topic_filter.get_reference();
 
             auto ret = dds_configuration->content_topic_filter_dict.insert(
                 std::make_pair(key, filter)


### PR DESCRIPTION
## Description

This PR fixes two macOS compilation issues in Fast DDS Spy.

## Changes

1. Make `std::string` extraction explicit in `fastddsspy_yaml` by using `get_reference()` instead of relying on implicit conversion from `utils::Fuzzy<std::string>`.
2. Rename the CLI option enum entry `DOMAIN` to `DOMAIN_ID` in `fastddsspy_tool` to avoid colliding with the `DOMAIN` macro defined by macOS system headers.

## Errors

### 1. 
```bash
--- stderr: fastddsspy_yaml                             
/Users/macmini/workspace_dev_utils/src/Fast-DDS-Spy/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp:189:31: error: call to constructor of 'const std::string' (aka 'const basic_string<char, char_traits<char>, allocator<char>>') is ambiguous
  189 |             const std::string key(topic.first->topic_name);
      |                               ^   ~~~~~~~~~~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/string:822:5: note: candidate constructor
  822 |     basic_string(const basic_string& __str);
      |     ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/string:827:5: note: candidate constructor
  827 |     basic_string(basic_string&& __str)
      |     ^
/Users/macmini/workspace_dev_utils/src/Fast-DDS-Spy/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp:193:21: error: ambiguous conversion for static_cast from 'utils::Fuzzy<std::string>' (aka 'Fuzzy<basic_string<char, char_traits<char>, allocator<char>>>') to 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char>>')
  193 |                     static_cast<std::string>(topic.first->content_topic_filter);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/string:822:5: note: candidate constructor
  822 |     basic_string(const basic_string& __str);
      |     ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/string:827:5: note: candidate constructor
  827 |     basic_string(basic_string&& __str)
```

### 2.
```bash
In file included from /Users/macmini/workspace_dev_utils/src/Fast-DDS-Spy/fastddsspy_tool/src/cpp/user_interface/arguments_configuration.cpp:30:
/Users/macmini/workspace_dev_utils/src/Fast-DDS-Spy/fastddsspy_tool/src/cpp/user_interface/arguments_configuration.hpp:102:5: error: expected identifier
  102 |     DOMAIN,
      |     ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/math.h:781:17: note: expanded from macro 'DOMAIN'
  781 | #define DOMAIN          1
      |                         ^
/Users/macmini/workspace_dev_utils/src/Fast-DDS-Spy/fastddsspy_tool/src/cpp/user_interface/arguments_configuration.cpp:105:22: error: expected unqualified-id
  105 |         optionIndex::DOMAIN,
```