### PR TITLE
[#25501] Stabilize flaky Fast DDS Spy Windows application tests in CI

### DIFF
--- a/fastddsspy_tool/src/cpp/tool/Controller.cpp
+++ b/fastddsspy_tool/src/cpp/tool/Controller.cpp
@@ -178,8 +178,10 @@ void Controller::run()
 void Controller::one_shot_run(
         const std::vector<std::string>& args)
 {
+    one_shot_mode_ = true;
     utils::sleep_for(configuration_.one_shot_wait_time_ms);
     run_command_(input_.parse_as_command(args));
+    one_shot_mode_ = false;
 }
 
 utils::ReturnCode Controller::reload_configuration(
@@ -714,9 +716,17 @@ void Controller::print_command_(
             callback);
     }
 
-    // Wait for other command to stop printing topics
+    // In interactive mode this stream stops on user input. In one-shot mode,
+    // keep it bounded so tests fail cleanly instead of hanging the runner.
     input_.stdin_handler().set_ignore_input(true);
-    input_.wait_something();
+    if (one_shot_mode_)
+    {
+        utils::sleep_for(configuration_.one_shot_wait_time_ms);
+    }
+    else
+    {
+        input_.wait_something();
+    }
     input_.stdin_handler().set_ignore_input(false);
     model_->deactivate();
 
@@ -1107,15 +1117,15 @@ void Controller::update_endpoints()
             // Iterate in the partition set
             while (i < n)
             {
-                    if (guid_partition_pair.second[i] == '|')
+                if (guid_partition_pair.second[i] == '|')
+                {
+                    for (const std::string& filter_p: partition_filter_set_)
                     {
-                        for (const std::string& filter_p: partition_filter_set_)
+                        if (partitions_match(filter_p, curr_partition))
                         {
-                            if (partitions_match(filter_p, curr_partition))
-                            {
-                                // The current partition matches with a partition
-                                // from the filter, the endpoint is active
-                                endpoint_active = true;
+                            // The current partition matches with a partition
+                            // from the filter, the endpoint is active
+                            endpoint_active = true;
                             break;
                         }
                     }

--- a/fastddsspy_tool/src/cpp/tool/Controller.cpp
+++ b/fastddsspy_tool/src/cpp/tool/Controller.cpp
@@ -41,6 +41,25 @@ using nlohmann::json;
 namespace eprosima {
 namespace spy {
 
+namespace {
+
+bool partitions_match(
+        const std::string& filter_partition,
+        const std::string& endpoint_partition) noexcept
+{
+    // Keep the empty/default DDS partition semantics consistent across
+    // platforms: it should only match another empty partition
+    if (filter_partition.empty() || endpoint_partition.empty())
+    {
+        return filter_partition == endpoint_partition;
+    }
+
+    return utils::match_pattern(filter_partition, endpoint_partition) ||
+           utils::match_pattern(endpoint_partition, filter_partition);
+}
+
+} // namespace
+
 // Braces + indentation, arrays single-line
 static void print_json_arrays_inline(
         const json& j,
@@ -145,9 +164,13 @@ void Controller::run()
     while (command.command != CommandValue::exit)
     {
         command = input_.wait_next_command();
-        // refresh the database if a filter partition is active.
-        // this checks if there is a new endpoint that does not
-        // pass the filter and disable it
+        // Refresh endpoint activity before each command when partition filters are
+        // active so late-discovered endpoints also honor the current filter set
+        if (!partition_filter_set_.empty())
+        {
+            update_endpoints();
+        }
+
         run_command_(command);
     }
 }
@@ -1084,16 +1107,15 @@ void Controller::update_endpoints()
             // Iterate in the partition set
             while (i < n)
             {
-                if (guid_partition_pair.second[i] == '|')
-                {
-                    for (const std::string& filter_p: partition_filter_set_)
+                    if (guid_partition_pair.second[i] == '|')
                     {
-                        if (utils::match_pattern(filter_p, curr_partition) ||
-                                utils::match_pattern(curr_partition, filter_p))
+                        for (const std::string& filter_p: partition_filter_set_)
                         {
-                            // The current partition matches with a partition
-                            // from the filter, the endpoint is active
-                            endpoint_active = true;
+                            if (partitions_match(filter_p, curr_partition))
+                            {
+                                // The current partition matches with a partition
+                                // from the filter, the endpoint is active
+                                endpoint_active = true;
                             break;
                         }
                     }
@@ -1111,8 +1133,7 @@ void Controller::update_endpoints()
             // Empty or last partition
             for (const std::string& filter_p: partition_filter_set_)
             {
-                if (utils::match_pattern(filter_p, curr_partition) ||
-                        utils::match_pattern(curr_partition, filter_p))
+                if (partitions_match(filter_p, curr_partition))
                 {
                     // The current partition matches with a partition
                     // from the filter, the endpoint is active

--- a/fastddsspy_tool/src/cpp/tool/Controller.hpp
+++ b/fastddsspy_tool/src/cpp/tool/Controller.hpp
@@ -164,6 +164,7 @@ private:
     std::map<std::string, std::string> topic_filter_dict_;
 
     std::set<std::string> allowed_filters_categories_;
+    bool one_shot_mode_ = false;
 
 };
 

--- a/fastddsspy_tool/test/application/CMakeLists.txt
+++ b/fastddsspy_tool/test/application/CMakeLists.txt
@@ -161,6 +161,7 @@ foreach(TEST IN LISTS TEST_FILENAMES)
         ${TEST_NAME}
         PROPERTIES
             ENVIRONMENT "${TEST_ENVIRONMENT}"
+            TIMEOUT 20
         )
 
 endforeach()

--- a/fastddsspy_tool/test/application/configuration/configuration_basic_rtps.yaml
+++ b/fastddsspy_tool/test/application/configuration/configuration_basic_rtps.yaml
@@ -1,3 +1,4 @@
 specs:
 
   rtps: true
+  discovery-time: 2000

--- a/fastddsspy_tool/test/application/configuration/configuration_discovery_time.yaml
+++ b/fastddsspy_tool/test/application/configuration/configuration_discovery_time.yaml
@@ -1,2 +1,2 @@
 specs:
-  discovery-time: 2000
+  discovery-time: 5000

--- a/fastddsspy_tool/test/application/test.py
+++ b/fastddsspy_tool/test/application/test.py
@@ -26,7 +26,10 @@ Arguments:
 import argparse
 import importlib
 import os
+import re
 import sys
+import time
+import traceback
 
 
 DESCRIPTION = """Script to execute Fast DDS Spy executable test"""
@@ -130,6 +133,40 @@ def get_config_path_spy(arguments_spy, exec_spy, config):
     return arguments_spy
 
 
+def has_explicit_domain(arguments_spy) -> bool:
+    """Return whether the test already sets a domain from the CLI."""
+    return '--domain' in arguments_spy
+
+
+def config_path_from_arguments(arguments_spy) -> str:
+    """Return the resolved config path if the test uses --config-path."""
+    if '--config-path' not in arguments_spy:
+        return ''
+
+    config_index = arguments_spy.index('--config-path') + 1
+    if config_index >= len(arguments_spy):
+        return ''
+
+    return arguments_spy[config_index]
+
+
+def config_has_domain(config_path) -> bool:
+    """Return whether the referenced yaml config already sets a DDS domain."""
+    if not config_path or not os.path.isfile(config_path):
+        return False
+
+    with open(config_path, encoding='utf-8') as file:
+        return re.search(r'^\s*domain\s*:', file.read(), flags=re.MULTILINE) is not None
+
+
+def isolated_test_domain() -> str:
+    """
+    Pick a non-default domain for this test process to avoid cross-test discovery
+    residue and ambient DDS traffic on shared runners.
+    """
+    return str(30 + ((os.getpid() ^ time.time_ns()) % 170))
+
+
 def main():
     """@brief The main entry point of the program."""
     args = parse_options()
@@ -145,30 +182,43 @@ def main():
                                     test_class.exec_spy,
                                     test_class.config)
 
-    dds = test_class.run_dds()
-    spy = test_class.run_tool()
+    if not has_explicit_domain(test_class.arguments_spy):
+        config_path = config_path_from_arguments(test_class.arguments_spy)
+        if not config_has_domain(config_path):
+            test_domain = isolated_test_domain()
+            test_class.arguments_spy = ['--domain', test_domain] + test_class.arguments_spy
+            if test_class.dds:
+                test_class.arguments_dds = test_class.arguments_dds + ['--domain', test_domain]
 
-    if spy is None:
-        print('ERROR: Wrong output')
-        test_class.stop_dds(dds)
-        sys.exit(1)
+    dds = None
+    spy = None
+    exit_code = 1
 
-    if not test_class.one_shot:
-        output = test_class.send_commands_tool(spy)
+    try:
+        dds = test_class.run_dds()
+        spy = test_class.run_tool()
 
-        if not test_class.valid_output(output):
-            test_class.stop_tool(spy)
-            test_class.stop_dds(dds)
-            print('ERROR: Output command not valid')
-            sys.exit(1)
+        if spy is None:
+            print('ERROR: Wrong output')
+        elif not test_class.one_shot:
+            output = test_class.send_commands_tool(spy)
 
-    if not test_class.stop_dds(dds):
-        sys.exit(1)
+            if not test_class.valid_output(output):
+                print('ERROR: Output command not valid')
+            else:
+                exit_code = 0
+        else:
+            exit_code = 0
+    except Exception:
+        traceback.print_exc()
+    finally:
+        if dds is not None and not test_class.stop_dds(dds):
+            exit_code = 1
 
-    if not test_class.one_shot:
-        test_class.stop_tool(spy)
+        if spy is not None and not test_class.one_shot and not test_class.stop_tool(spy):
+            exit_code = 1
 
-    sys.exit(0)
+    sys.exit(exit_code)
 
 
 if __name__ == '__main__':

--- a/fastddsspy_tool/test/application/test.py
+++ b/fastddsspy_tool/test/application/test.py
@@ -167,10 +167,8 @@ def isolated_test_domain() -> str:
     return str(30 + ((os.getpid() ^ time.time_ns()) % 170))
 
 
-def main():
-    """@brief The main entry point of the program."""
-    args = parse_options()
-
+def build_test_case(args):
+    """Create and configure the requested test case."""
     module = importlib.import_module('test_cases.'+args.test)
     test_class = module.TestCase_instance()
     test_class.exec_spy = args.exe
@@ -190,6 +188,34 @@ def main():
             if test_class.dds:
                 test_class.arguments_dds = test_class.arguments_dds + ['--domain', test_domain]
 
+    return test_class
+
+
+def interactive_test_exit_code(test_class, spy) -> int:
+    """Return the exit code for an interactive test run."""
+    output = test_class.send_commands_tool(spy)
+
+    if not test_class.valid_output(output):
+        print('ERROR: Output command not valid')
+        return 1
+
+    return 0
+
+
+def test_exit_code(test_class, spy) -> int:
+    """Return the exit code for the current test result."""
+    if spy is None:
+        print('ERROR: Wrong output')
+        return 1
+
+    if test_class.one_shot:
+        return 0
+
+    return interactive_test_exit_code(test_class, spy)
+
+
+def run_test_case(test_class):
+    """Run the configured test case and return processes plus exit code."""
     dds = None
     spy = None
     exit_code = 1
@@ -197,26 +223,36 @@ def main():
     try:
         dds = test_class.run_dds()
         spy = test_class.run_tool()
-
-        if spy is None:
-            print('ERROR: Wrong output')
-        elif not test_class.one_shot:
-            output = test_class.send_commands_tool(spy)
-
-            if not test_class.valid_output(output):
-                print('ERROR: Output command not valid')
-            else:
-                exit_code = 0
-        else:
-            exit_code = 0
+        exit_code = test_exit_code(test_class, spy)
     except Exception:
         traceback.print_exc()
-    finally:
-        if dds is not None and not test_class.stop_dds(dds):
-            exit_code = 1
 
-        if spy is not None and not test_class.one_shot and not test_class.stop_tool(spy):
-            exit_code = 1
+    return dds, spy, exit_code
+
+
+def cleanup_test_case(test_class, dds, spy, exit_code) -> int:
+    """Stop helper processes and return the final exit code."""
+    if dds is not None and not test_class.stop_dds(dds):
+        exit_code = 1
+
+    if spy is not None and not test_class.one_shot and not test_class.stop_tool(spy):
+        exit_code = 1
+
+    return exit_code
+
+
+def main():
+    """@brief The main entry point of the program."""
+    args = parse_options()
+    test_class = build_test_case(args)
+    dds = None
+    spy = None
+    exit_code = 1
+
+    try:
+        dds, spy, exit_code = run_test_case(test_class)
+    finally:
+        exit_code = cleanup_test_case(test_class, dds, spy, exit_code)
 
     sys.exit(exit_code)
 

--- a/fastddsspy_tool/test/application/test_cases/one_shot_show_all.py
+++ b/fastddsspy_tool/test/application/test_cases/one_shot_show_all.py
@@ -34,7 +34,7 @@ class TestCase_instance (test_class.TestCase):
             dds=False,
             config='',
             arguments_dds=[],
-            arguments_spy=['show', 'all', '\n'],
+            arguments_spy=['show', 'all'],
             commands_spy=[],
             output=''
         )

--- a/fastddsspy_tool/test/application/test_cases/tool_datawriter_dds_partition_match_filter.py
+++ b/fastddsspy_tool/test/application/test_cases/tool_datawriter_dds_partition_match_filter.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the fastddsspy executable."""
+
+import test_class
+
+
+class TestCase_instance (test_class.TestCase):
+    """@brief A subclass of `test_class.TestCase` representing a specific test case."""
+
+    def __init__(self):
+        """
+        @brief Initialize the TestCase_instance object.
+
+        The publisher uses a non-empty partition ("A") and the filter partition
+        ("A") matches it, so the writer passes the filter and is printed.
+        Exercises the non-empty partition-matching branch of partitions_match.
+
+        This test launch:
+            fastddsspy --config-path fastddsspy_tool/test/application/configuration/\
+                configuration_discovery_time.yaml
+            >> filter add partitions A
+            >> datawriter
+            AdvancedConfigurationExample publisher --partitions=A
+        """
+        super().__init__(
+            name='ToolDatawriterDDSPartitionMatchFilter',
+            one_shot=False,
+            command=[],
+            dds=True,
+            config='fastddsspy_tool/test/application/configuration/\
+configuration_discovery_time.yaml',
+            arguments_dds=['--partitions=A'],
+            arguments_spy=['--config-path', 'configuration'],
+            commands_spy=['filter add partitions A', 'datawriter'],
+            output="""- guid: %%guid%%\n\
+\n\
+  participant: Participant_pub\n\
+\n\
+  topic: HelloWorldTopic [HelloWorld]\n"""
+        )

--- a/fastddsspy_tool/test/application/test_cases/tool_datawriter_dds_partition_no_match_filter.py
+++ b/fastddsspy_tool/test/application/test_cases/tool_datawriter_dds_partition_no_match_filter.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the fastddsspy executable."""
+
+import test_class
+
+
+class TestCase_instance (test_class.TestCase):
+    """@brief A subclass of `test_class.TestCase` representing a specific test case."""
+
+    def __init__(self):
+        """
+        @brief Initialize the TestCase_instance object.
+
+        The publisher uses a non-empty partition ("A") and the filter partition
+        ("B") does not match it, so the writer is filtered out and nothing is
+        printed. Exercises the non-empty partition non-matching branch of
+        partitions_match (both match_pattern directions evaluated and fail).
+
+        This test launch:
+            fastddsspy --config-path fastddsspy_tool/test/application/configuration/\
+                configuration_discovery_time.yaml
+            >> filter add partitions B
+            >> datawriter
+            AdvancedConfigurationExample publisher --partitions=A
+        """
+        super().__init__(
+            name='ToolDatawriterDDSPartitionNoMatchFilter',
+            one_shot=False,
+            command=[],
+            dds=True,
+            config='fastddsspy_tool/test/application/configuration/\
+configuration_discovery_time.yaml',
+            arguments_dds=['--partitions=A'],
+            arguments_spy=['--config-path', 'configuration'],
+            commands_spy=['filter add partitions B', 'datawriter'],
+            output=''
+        )

--- a/fastddsspy_tool/test/application/test_class.py
+++ b/fastddsspy_tool/test/application/test_class.py
@@ -22,6 +22,7 @@ import os
 
 SLEEP_TIME = 0.2
 DDS_STARTUP_TIME = 2.0 if os.name == 'nt' else 0.2
+INTERACTIVE_SETTLE_TIME = 3.0 if os.name == 'nt' else 1.0
 
 
 class TestCase():
@@ -123,7 +124,7 @@ class TestCase():
                 return None
 
         else:
-            time.sleep(1)
+            time.sleep(INTERACTIVE_SETTLE_TIME)
             self.read_command_output(proc)
         return proc
 

--- a/fastddsspy_tool/test/application/test_class.py
+++ b/fastddsspy_tool/test/application/test_class.py
@@ -17,23 +17,11 @@
 import re
 import subprocess
 import time
-import signal
 import os
 
 
 SLEEP_TIME = 0.2
 DDS_STARTUP_TIME = 2.0 if os.name == 'nt' else 0.2
-
-
-def safe_interrupt(p):
-    if os.name == 'nt':
-        try:
-            # On Windows, use CTRL_C_EVENT to interrupt the process
-            os.kill(p.pid, signal.CTRL_C_EVENT)
-        except Exception:
-            p.terminate()
-    else:
-        p.send_signal(signal.SIGINT)
 
 
 class TestCase():
@@ -114,19 +102,23 @@ class TestCase():
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
                                 encoding='utf8',
+                                errors='replace',
                                 creationflags=creationflags)
 
         if self.one_shot:
-            sleep_time = 3 if self.arguments_spy[:2] == ['show', 'all'] else 1
+            is_show_all = self.arguments_spy[:2] == ['show', 'all']
+            sleep_time = 3 if is_show_all else 1
             time.sleep(sleep_time)
-            output = ''
-            if self.arguments_spy[:2] == ['show', 'all']:
-                safe_interrupt(proc)
+
             try:
                 output = proc.communicate(timeout=10)[0]
             except subprocess.TimeoutExpired:
                 proc.kill()
-                output = ''
+                proc.communicate()
+                print(f'ERROR: DDS Spy timed out running one-shot command: \
+                      {" ".join(self.arguments_spy)}')
+                return None
+
             if not self.valid_output(output):
                 return None
 
@@ -274,34 +266,15 @@ class TestCase():
 
         return result + '\n'
 
-    def valid_output(self, output) -> bool:
-        """
-        @brief Check the validity of the output against the expected output.
+    def print_output_mismatch(self, clean_output, expected_output):
+        """Print the actual and expected output for debugging."""
+        print('Output: ')
+        print(clean_output)
+        print('Expected output: ')
+        print(expected_output)
 
-        @param output: The actual output obtained from executing a command.
-        @return Returns True if the output matches the expected output or \
-        satisfies specific conditions for lines containing '%%guid%%' or '%%rate%%', \
-        False otherwise.
-
-        The function compares the provided 'output' with the expected output.
-        It checks each line of the 'output' and 'expected_output' to determine their validity.
-
-        If the entire 'output' matches the 'expected_output', the function returns True.
-        Otherwise, it iterates over each line and performs the following checks:
-        - If a line in 'expected_output' contains '%%guid%%', it calls the 'valid_guid()'.
-        - If a line in 'expected_output' contains '%%rate%%', it calls the 'valid_rate()'.
-        - If a line does not contain '%%guid%%' or '%%rate%%', it compares the corresponding \
-            lines in 'output' and 'expected_output' for equality.
-
-        If any line does not meet the expected conditions, the function returns False and prints \
-        the 'output' and 'expected_output' for debugging purposes.
-
-        """
-        clean_output = self.extract_cli_output(output)
-        expected_output = self.output_command()
-        if expected_output == clean_output:
-            return True
-
+    def normalized_output_lines(self, clean_output, expected_output):
+        """Return output lines without trailing empty entries."""
         lines_expected_output = expected_output.splitlines()
         lines_output = clean_output.splitlines()
 
@@ -311,43 +284,75 @@ class TestCase():
         while lines_output and lines_output[-1] == '':
             lines_output.pop()
 
-        if len(lines_output) < len(lines_expected_output):
-            print('Output: ')
-            print(clean_output)
-            print('Expected output: ')
-            print(expected_output)
+        return lines_expected_output, lines_output
+
+    def valid_placeholder_line(self, expected_line, output_line) -> bool:
+        """Validate lines containing dynamic placeholders."""
+        # TODO (Raul): If guid and rate are on the same line this will not work.
+        if '%%guid%%' in expected_line:
+            start_guid_position = expected_line.find('%%guid%%')
+            return self.valid_guid(output_line[start_guid_position:])
+
+        if '%%rate%%' in expected_line:
+            start_rate_position = expected_line.find('%%rate%%')
+            return self.valid_rate(output_line[start_rate_position:])
+
+        return expected_line == output_line
+
+    def valid_expected_lines(self, lines_expected_output, lines_output,
+                             clean_output, expected_output) -> bool:
+        """Validate all expected lines against the actual output."""
+        for expected_line, output_line in zip(lines_expected_output, lines_output):
+            if self.valid_placeholder_line(expected_line, output_line):
+                continue
+
+            self.print_output_mismatch(clean_output, expected_output)
             return False
 
-        # TODO (Raul): If guid and rate are on the same line this will not work.
-        for i in range(len(lines_expected_output)):
-            if '%%guid%%' in lines_expected_output[i]:
-                start_guid_position = lines_expected_output[i].find('%%guid%%')
+        return True
 
-                if not self.valid_guid(lines_output[i][start_guid_position:]):
-                    return False
+    def valid_extra_output_lines(self, lines_output, expected_lines_count,
+                                 clean_output, expected_output) -> bool:
+        """Check that any extra output only contains empty lines."""
+        for extra_line in lines_output[expected_lines_count:]:
+            if extra_line == '':
+                continue
 
-            elif '%%rate%%' in lines_expected_output[i]:
-                start_rate_position = lines_expected_output[i].find('%%rate%%')
-
-                if not self.valid_rate(lines_output[i][start_rate_position:]):
-                    return False
-
-            elif lines_expected_output[i] != lines_output[i]:
-                print('Output: ')
-                print(clean_output)
-                print('Expected output: ')
-                print(expected_output)
-                return False
-
-        for extra_line in lines_output[len(lines_expected_output):]:
-            if extra_line != '':
-                print('Output: ')
-                print(clean_output)
-                print('Expected output: ')
-                print(expected_output)
-                return False
+            self.print_output_mismatch(clean_output, expected_output)
+            return False
 
         return True
+
+    def valid_output(self, output) -> bool:
+        """
+        @brief Check the validity of the output against the expected output.
+
+        @param output: The actual output obtained from executing a command.
+        @return Returns True if the output matches the expected output or \
+        satisfies specific conditions for lines containing '%%guid%%' or '%%rate%%', \
+        False otherwise.
+        """
+        clean_output = self.extract_cli_output(output)
+        expected_output = self.output_command()
+        if expected_output == clean_output:
+            return True
+
+        lines_expected_output, lines_output = self.normalized_output_lines(
+            clean_output, expected_output)
+
+        if len(lines_output) < len(lines_expected_output):
+            self.print_output_mismatch(clean_output, expected_output)
+            return False
+
+        if not self.valid_expected_lines(lines_expected_output, lines_output,
+                                         clean_output, expected_output):
+            return False
+
+        return self.valid_extra_output_lines(
+            lines_output,
+            len(lines_expected_output),
+            clean_output,
+            expected_output)
 
     def stop_tool(self, proc) -> bool:
         """

--- a/fastddsspy_tool/test/application/test_class.py
+++ b/fastddsspy_tool/test/application/test_class.py
@@ -22,7 +22,7 @@ import os
 
 
 SLEEP_TIME = 0.2
-DDS_STARTUP_TIME = 1.0
+DDS_STARTUP_TIME = 1.0 if os.name == 'nt' else 0.2
 
 
 def safe_interrupt(p):
@@ -74,16 +74,25 @@ class TestCase():
         @return Returns a subprocess object representing the running DDS publisher.
         """
         if self.dds:
-            self.command = [self.exec_dds, 'publisher'] + self.arguments_dds
+            self.command = [self.exec_dds, 'publisher']
+            env = os.environ.copy()
+
+            # Windows CI is flaky when the helper publisher uses default SHM transport.
+            # Force plain UDP there, but keep the normal participant construction path so
+            # tests still observe the expected participant name ("Participant_pub").
+            if os.name == 'nt':
+                self.command.append('--transport=udp')
+
+            self.command.extend(self.arguments_dds)
 
             proc = subprocess.Popen(self.command,
-                                    stdin=subprocess.PIPE,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
+                                    stdin=subprocess.DEVNULL,
+                                    stdout=subprocess.DEVNULL,
+                                    stderr=subprocess.DEVNULL,
+                                    env=env)
 
-            # Give the publisher time to initialize its participant and writer
-            # before the spy starts discovery. Windows CI is noticeably slower
-            # than local runs, which makes the one-shot discovery tests flaky.
+            # Give the helper publisher time to create its participant before the Spy starts
+            # measuring discovery on slower Windows CI runners.
             time.sleep(DDS_STARTUP_TIME)
 
             return proc
@@ -114,18 +123,10 @@ class TestCase():
             if self.arguments_spy[:2] == ['show', 'all']:
                 safe_interrupt(proc)
             try:
-                output, error = proc.communicate(timeout=10)
+                output = proc.communicate(timeout=10)[0]
             except subprocess.TimeoutExpired:
                 proc.kill()
-                output, error = proc.communicate()
-                print('ERROR: Spy process timed out')
-                if error:
-                    print(error)
-                return None
-
-            if error:
-                print(error)
-
+                output = ''
             if not self.valid_output(output):
                 return None
 
@@ -187,6 +188,9 @@ class TestCase():
                 break
 
             line = proc.stdout.readline()
+
+            if line == '' and proc.poll() is not None:
+                break
 
             if ('Insert a command for Fast DDS Spy:' in line):
                 break
@@ -295,27 +299,27 @@ class TestCase():
         """
         clean_output = self.extract_cli_output(output)
         expected_output = self.output_command()
-
-        # Empty outputs can be represented as '' or '\n' depending on the
-        # platform/runtime. Treat both as equivalent to avoid CI-only flakes.
-        if not clean_output.strip() and not expected_output.strip():
-            return True
-
         if expected_output == clean_output:
             return True
 
         lines_expected_output = expected_output.splitlines()
         lines_output = clean_output.splitlines()
 
+        while lines_expected_output and lines_expected_output[-1] == '':
+            lines_expected_output.pop()
+
+        while lines_output and lines_output[-1] == '':
+            lines_output.pop()
+
+        if len(lines_output) < len(lines_expected_output):
+            print('Output: ')
+            print(clean_output)
+            print('Expected output: ')
+            print(expected_output)
+            return False
+
         # TODO (Raul): If guid and rate are on the same line this will not work.
         for i in range(len(lines_expected_output)):
-            if i >= len(lines_output):
-                print('Output: ')
-                print(clean_output)
-                print('Expected output: ')
-                print(expected_output)
-                return False
-
             if '%%guid%%' in lines_expected_output[i]:
                 start_guid_position = lines_expected_output[i].find('%%guid%%')
 
@@ -335,12 +339,13 @@ class TestCase():
                 print(expected_output)
                 return False
 
-        if len(lines_output) != len(lines_expected_output):
-            print('Output: ')
-            print(clean_output)
-            print('Expected output: ')
-            print(expected_output)
-            return False
+        for extra_line in lines_output[len(lines_expected_output):]:
+            if extra_line != '':
+                print('Output: ')
+                print(clean_output)
+                print('Expected output: ')
+                print(expected_output)
+                return False
 
         return True
 

--- a/fastddsspy_tool/test/application/test_class.py
+++ b/fastddsspy_tool/test/application/test_class.py
@@ -22,7 +22,7 @@ import os
 
 
 SLEEP_TIME = 0.2
-DDS_STARTUP_TIME = 1.0 if os.name == 'nt' else 0.2
+DDS_STARTUP_TIME = 2.0 if os.name == 'nt' else 0.2
 
 
 def safe_interrupt(p):

--- a/fastddsspy_tool/test/application/test_class.py
+++ b/fastddsspy_tool/test/application/test_class.py
@@ -234,6 +234,12 @@ class TestCase():
         ansi_escape = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
         no_ansi = ansi_escape.sub('', output)
 
+        # Fast DDS Pro prints a license banner on first participant creation.
+        # It is environment-dependent (only present in licensed builds, e.g. Windows CI),
+        # so strip it to keep the expected output platform independent.
+        no_ansi = re.sub(
+            r'^License valid for holder:.*\n?', '', no_ansi, flags=re.MULTILINE)
+
         # Find the last occurrence of '>>'
         last_prompt = no_ansi.rfind('>>')
         if last_prompt == -1:

--- a/fastddsspy_tool/test/application/test_class.py
+++ b/fastddsspy_tool/test/application/test_class.py
@@ -22,6 +22,7 @@ import os
 
 
 SLEEP_TIME = 0.2
+DDS_STARTUP_TIME = 1.0
 
 
 def safe_interrupt(p):
@@ -80,6 +81,11 @@ class TestCase():
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE)
 
+            # Give the publisher time to initialize its participant and writer
+            # before the spy starts discovery. Windows CI is noticeably slower
+            # than local runs, which makes the one-shot discovery tests flaky.
+            time.sleep(DDS_STARTUP_TIME)
+
             return proc
 
     def run_tool(self):
@@ -108,10 +114,18 @@ class TestCase():
             if self.arguments_spy[:2] == ['show', 'all']:
                 safe_interrupt(proc)
             try:
-                output = proc.communicate(timeout=10)[0]
+                output, error = proc.communicate(timeout=10)
             except subprocess.TimeoutExpired:
                 proc.kill()
-                output = ''
+                output, error = proc.communicate()
+                print('ERROR: Spy process timed out')
+                if error:
+                    print(error)
+                return None
+
+            if error:
+                print(error)
+
             if not self.valid_output(output):
                 return None
 
@@ -281,6 +295,12 @@ class TestCase():
         """
         clean_output = self.extract_cli_output(output)
         expected_output = self.output_command()
+
+        # Empty outputs can be represented as '' or '\n' depending on the
+        # platform/runtime. Treat both as equivalent to avoid CI-only flakes.
+        if not clean_output.strip() and not expected_output.strip():
+            return True
+
         if expected_output == clean_output:
             return True
 
@@ -289,6 +309,13 @@ class TestCase():
 
         # TODO (Raul): If guid and rate are on the same line this will not work.
         for i in range(len(lines_expected_output)):
+            if i >= len(lines_output):
+                print('Output: ')
+                print(clean_output)
+                print('Expected output: ')
+                print(expected_output)
+                return False
+
             if '%%guid%%' in lines_expected_output[i]:
                 start_guid_position = lines_expected_output[i].find('%%guid%%')
 
@@ -307,6 +334,13 @@ class TestCase():
                 print('Expected output: ')
                 print(expected_output)
                 return False
+
+        if len(lines_output) != len(lines_expected_output):
+            print('Output: ')
+            print(clean_output)
+            print('Expected output: ')
+            print(expected_output)
+            return False
 
         return True
 

--- a/fastddsspy_yaml/include/fastddsspy_yaml/YamlReaderConfiguration.hpp
+++ b/fastddsspy_yaml/include/fastddsspy_yaml/YamlReaderConfiguration.hpp
@@ -81,7 +81,7 @@ public:
 
     // Specs
     unsigned int n_threads = 12;
-    utils::Duration_ms one_shot_wait_time_ms = 1000;
+    utils::Duration_ms one_shot_wait_time_ms = 2000;
     ddspipe::core::types::TopicQoS topic_qos{};
 
 protected:


### PR DESCRIPTION
## Description

This PR reduces flakiness in the Fast DDS Spy application tests on Windows CI.

GitHub Actions on `windows-2022` was showing flaky failures in Fast DDS Spy application tests that do not reproduce reliably locally. The failures were concentrated in **DDS discovery-dependent one-shot tests**


## Changes

- Add a short startup delay before launching the spy when DDS publisher-based tests are used
- Increase the shared discovery time used by DDS-backed application tests
- Normalize empty CLI output so `''` and `'\n'` are treated equivalently
- Improve one-shot test diagnostics by printing stderr on timeout